### PR TITLE
Radio group

### DIFF
--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.component.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.component.js
@@ -1,0 +1,22 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export const RadioGroup = ({
+	name,
+	children,
+	...props
+}) => {
+	const namedChildren = () => {
+		return React.Children.map(children, (child) => {
+		  return React.cloneElement(child, {
+			name: name
+		  });
+		});
+	 };
+	 return <React.Fragment>{namedChildren()}</React.Fragment>;
+}
+
+RadioGroup.propTypes = {
+	name: PropTypes.string.isRequired
+}
+

--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { RadioGroup } from "./index"
+import {Radio} from "../Radio/index"
+
+
+describe("RadioGroup", () => {
+	
+	test("does not render any radios if no children passed", async () => {
+		render(
+			<RadioGroup name="my-radiogroup"> 
+			</RadioGroup>
+		)
+		expect(() => {
+			screen.getByRole("radio");
+		  }).toThrow()
+	})
+	
+	test("renders radios as passed", async () => {
+		render(
+			<RadioGroup name="my-radiogroup"> 
+				<Radio />
+				<Radio />
+				<Radio />
+			</RadioGroup>
+		)
+		expect(screen.getAllByRole("radio")).toHaveLength(3)
+	})
+	
+	test("renders named checkboxes as passed", async () => {
+		render(
+			<RadioGroup name="my-radiogroup"> 
+				<Radio />
+			</RadioGroup>
+		)
+		expect(screen.getByRole("radio")).toHaveAttribute('name', "my-radiogroup")
+	})
+	
+})

--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { RadioGroup } from "./index"
 import {Radio} from "../Radio/index"
 

--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
@@ -27,7 +27,7 @@ describe("RadioGroup", () => {
 		expect(screen.getAllByRole("radio")).toHaveLength(3)
 	})
 	
-	test("renders named checkboxes as passed", async () => {
+	test("renders individually named checkboxes as passed", async () => {
 		render(
 			<RadioGroup name="my-radiogroup"> 
 				<Radio />

--- a/libs/juno-ui-components/src/components/RadioGroup/index.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/index.js
@@ -1,0 +1,1 @@
+export { RadioGroup } from "./RadioGroup.component"


### PR DESCRIPTION
Adds a RadioGroup component that does not render any markup itself. The RadioGroup component makes sure all child radio elements have the same name attribute, thus requiring the name attribute to be passed only once as a prop to the group and not the individual children:

```
<RadioGroup name="my-radiogroup">
    <Radio />
    <Radio />
</RadioGroup>
```

instead of

```
<Radio name="my-radiogroup" />
<Radio name="my-radiogroup" />
```
will render:

```
<input type="radio" name="my-radiogroup" />
<input type="radio" name="my-radiogroup" />
```

RadioGroup adds convenience and can be used to render any labels and additional markup that might be required in the future. Individual naming will still work.