### PR TITLE
Improve storybook

### DIFF
--- a/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.js
+++ b/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.js
@@ -12,8 +12,8 @@ export default {
 
 const Template = ({ items, ...args }) => (
 	  <CheckboxGroup {...args}>
-		{items.map((item) => (
-		  <CheckboxRow {...item} />
+		{items.map((item, i) => (
+		  <CheckboxRow {...item} key={`${i}`} />
 		))}
 	  </CheckboxGroup>
 	)
@@ -23,9 +23,9 @@ export const Default = Template.bind({})
 Default.args = {
 	name: "Default ChechboxGroup",
 	items: [
-		{ ...CheckboxRowStory.args, value: "val-1" , id: "checkbox-1", key: "1" },
-		{ ...CheckboxRowStory.args, value: "val-2" , id: "checkbox-2", key: "2" },
-		{ ...CheckboxRowStory.args, value: "val-3" , id: "checkbox-3", key: "3"}
+		{ ...CheckboxRowStory.args, value: "val-1" , id: "checkbox-1"},
+		{ ...CheckboxRowStory.args, value: "val-2" , id: "checkbox-2"},
+		{ ...CheckboxRowStory.args, value: "val-3" , id: "checkbox-3"}
 	]
 }
 
@@ -34,9 +34,9 @@ WithLabel.args = {
 	name: "Labelled ChechboxGroup",
 	label: "A Labelled CheckboxGroup",
 	items: [
-		{ ...CheckboxRowStory.args, value: "val-l-1" , id: "checkbox-l-4", key: "l-1" },
-		{ ...CheckboxRowStory.args, value: "val-l-2" , id: "checkbox-l-5", key: "l-2" },
-		{ ...CheckboxRowStory.args, value: "val-l-3" , id: "checkbox-l-6", key: "l-3"}
+		{ ...CheckboxRowStory.args, value: "val-l-1" , id: "checkbox-l-4"},
+		{ ...CheckboxRowStory.args, value: "val-l-2" , id: "checkbox-l-5"},
+		{ ...CheckboxRowStory.args, value: "val-l-3" , id: "checkbox-l-6"}
 	]
 }
 
@@ -46,9 +46,9 @@ Required.args = {
 	label: "A Required, Labelled CheckboxGroup",
 	required: true,
 	items: [
-		{ ...CheckboxRowStory.args, value: "val-r-1" , id: "checkbox-r-4", key: "r-1" },
-		{ ...CheckboxRowStory.args, value: "val-r-2" , id: "checkbox-r-5", key: "r-2" },
-		{ ...CheckboxRowStory.args, value: "val-r-3" , id: "checkbox-r-6", key: "r-3"}
+		{ ...CheckboxRowStory.args, value: "val-r-1" , id: "checkbox-r-4"},
+		{ ...CheckboxRowStory.args, value: "val-r-2" , id: "checkbox-r-5"},
+		{ ...CheckboxRowStory.args, value: "val-r-3" , id: "checkbox-r-6"}
 	]
 }
 	

--- a/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.js
+++ b/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { CheckboxGroup } from "./index.js"
-import { Default as CheckboxRow, Checked as CheckedCheckboxRow } from "../CheckboxRow/CheckboxRow.stories"
+import { CheckboxRow } from "../CheckboxRow/index.js"
+// import CheckboxRow stories:
+import { Default as CheckboxRowStory } from "../CheckboxRow/CheckboxRow.stories"
 
 export default {
   title: "Design System/Forms/CheckboxGroup",
@@ -8,33 +10,45 @@ export default {
   argTypes: {},
 }
 
-const Template = ({ ...args }) => 
-	<CheckboxGroup {...args} />
-	
-const row1args = { ...CheckboxRow.args, value: "v1", id: "checkbox1" }
-	
-const row2args = { ...CheckboxRow.args, value: "v2", checked: true, id: "checkbox2" }
+const Template = ({ items, ...args }) => (
+	  <CheckboxGroup {...args}>
+		{items.map((item) => (
+		  <CheckboxRow {...item} />
+		))}
+	  </CheckboxGroup>
+	)
 
-const row3args = { ...CheckboxRow.args, value: "v3", id: "checkbox3"}
-		
+
 export const Default = Template.bind({})
 Default.args = {
-	name: 'my-checkboxgroup',
-	children: [<CheckboxRow {...row1args}/>, <CheckboxRow {...row2args} />, <CheckboxRow {...row3args} />]
+	name: "Default ChechboxGroup",
+	items: [
+		{ ...CheckboxRowStory.args, value: "val-1" , id: "checkbox-1", key: "1" },
+		{ ...CheckboxRowStory.args, value: "val-2" , id: "checkbox-2", key: "2" },
+		{ ...CheckboxRowStory.args, value: "val-3" , id: "checkbox-3", key: "3"}
+	]
 }
 
 export const WithLabel = Template.bind({})
 WithLabel.args = {
-	name: 'my-checkboxgroup',
-	label: "My Group of Checkboxes",
-	children: [<CheckboxRow {...row1args}/>, <CheckboxRow {...row2args} />, <CheckboxRow {...row3args} />]
+	name: "Labelled ChechboxGroup",
+	label: "A Labelled CheckboxGroup",
+	items: [
+		{ ...CheckboxRowStory.args, value: "val-l-1" , id: "checkbox-l-4", key: "l-1" },
+		{ ...CheckboxRowStory.args, value: "val-l-2" , id: "checkbox-l-5", key: "l-2" },
+		{ ...CheckboxRowStory.args, value: "val-l-3" , id: "checkbox-l-6", key: "l-3"}
+	]
 }
 
 export const Required = Template.bind({})
 Required.args = {
-	name: 'my-checkboxgroup',
-	label: "My Required Group of Checkboxes",
+	name: "Required Labelled ChechboxGroup",
+	label: "A Required, Labelled CheckboxGroup",
 	required: true,
-	selected: ["v1", "v3"],
-	children: [<CheckboxRow {...row1args}/>, <CheckboxRow {...row2args} />, <CheckboxRow {...row3args} />]
+	items: [
+		{ ...CheckboxRowStory.args, value: "val-r-1" , id: "checkbox-r-4", key: "r-1" },
+		{ ...CheckboxRowStory.args, value: "val-r-2" , id: "checkbox-r-5", key: "r-2" },
+		{ ...CheckboxRowStory.args, value: "val-r-3" , id: "checkbox-r-6", key: "r-3"}
+	]
 }
+	

--- a/libs/juno-ui-components/src/components/Form/Form.stories.js
+++ b/libs/juno-ui-components/src/components/Form/Form.stories.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Form } from "./index.js"
-import { Default as DefaultTextInputRow } from "../TextInputRow/TextInputRow.stories"
+import { TextInputRow } from "../TextInputRow/index.js"
+import { Default as DefaultTextInputRowStory } from "../TextInputRow/TextInputRow.stories"
 
 export default {
   title: "Design System/Forms/Form",
@@ -8,24 +9,32 @@ export default {
   argTypes: {},
 }
 
-const Template = (args) => (
+const Template = ({ items, ...args }) => (
   <Form {...args}> 
-    {args.children.map((child,i) => (
-      <DefaultTextInputRow {...child} key={`input-${i}`} />
+    {items.map((item, i) => (
+      <TextInputRow {...item} key={`input-${i}`} />
     ))}
   </Form>
 )
 
 export const Default = Template.bind({})
 Default.args = {
-  children: [DefaultTextInputRow.args]
+  items: 
+    [
+      { ...DefaultTextInputRowStory.args, label: "First Name", id: "d-1"},
+      { ...DefaultTextInputRowStory.args, label: "Last Name", id: "d-2" }
+    ]
 }
 
 
 export const WithTitle = Template.bind({})
 WithTitle.args = {
-	title: "Form Title",
-  children: [DefaultTextInputRow.args],
+	title: "Form With A Title",
+  items: 
+    [
+      { ...DefaultTextInputRowStory.args, label: "First Name", id: "wt-1" },
+      { ...DefaultTextInputRowStory.args, label: "Last Name", id: "wt-2" }
+    ]
 }
 
 

--- a/libs/juno-ui-components/src/components/FormSection/FormSection.stories.js
+++ b/libs/juno-ui-components/src/components/FormSection/FormSection.stories.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { FormSection } from "./index.js"
-import { Default as DefaultTextInputRow } from "../TextInputRow/TextInputRow.stories"
+import { TextInputRow } from "../TextInputRow/"
+import { Default as DefaultTextInputRowStory } from "../TextInputRow/TextInputRow.stories"
 
 export default {
   title: "Design System/Forms/FormSection",
@@ -8,22 +9,32 @@ export default {
   argTypes: {},
 }
 
-const Template = (args) => <FormSection {...args}>
-  {args.children.map((child, i) => (
-    <DefaultTextInputRow {...child}  key={`input-${i}`} />
-  ))}
-</FormSection>
+const Template = ({ items, ...args }) => (
+  <FormSection {...args}>
+    {items.map((item, i) => (
+      <TextInputRow {...item}  key={`input-${i}`} />
+    ))}
+  </FormSection>
+)
 
 export const Default = Template.bind({})
 Default.args = {
-  children: [DefaultTextInputRow.args]
+  items: 
+    [
+      { ...DefaultTextInputRowStory.args, label: "Address 1", id: "d-1" },
+      { ...DefaultTextInputRowStory.args, label: "Address 2", id: "d-2" }
+    ]
 }
 
 
 export const WithTitle = Template.bind({})
 WithTitle.args = {
 	title: "Form Section With Title",
-  children: [DefaultTextInputRow.args]
+  items: 
+  [
+    { ...DefaultTextInputRowStory.args, label: "Address 1", id: "wt-1" },
+    { ...DefaultTextInputRowStory.args, label: "Address 2", id: "wt-2" }
+  ]
 }
 
 

--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.stories.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.stories.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { RadioGroup } from "./index.js"
-import { Default as RadioRow, Checked as CheckedRadioRow } from "../RadioRow/RadioRow.stories"
+import { RadioRow } from "../RadioRow/"
+import { Default as RadioRowStory, Checked as CheckedRadioRowStory } from "../RadioRow/RadioRow.stories"
 
 export default {
   title: "Design System/Forms/RadioGroup",
@@ -8,46 +9,66 @@ export default {
   argTypes: {},
 }
 
-const Template = ({ ...args }) => 
-	<RadioGroup {...args} />
-	
-const row1args = { ...RadioRow.args, value: "v1", id: "radio1" }
-	
-const row2args = { ...RadioRow.args, value: "v2", checked: true, id: "radio2" }
+const Template = ({ items, ...args }) => (
+	<RadioGroup {...args}>
+		{items.map((item, i) => (
+			<RadioRow {...item} key={`${i}`} />
+		))}
+	</RadioGroup>
+)
 
-const row3args = { ...RadioRow.args, value: "v3", id: "radio3"}
-		
 export const Default = Template.bind({})
-
 Default.args = {
-	name: 'my-radiogroup',
-	selected: "v1",
-	children: [<RadioRow {...row1args}/>, <RadioRow {...row2args} />, <RadioRow {...row3args} />]
+	name: "default-radiogroup",
+	selected: "v-1",
+	items: 
+		[
+			{ ...RadioRowStory.args, label: "Option 1", value: "v-1" },
+			{ ...RadioRowStory.args, label: "Option 2", value: "v-2" },
+			{ ...RadioRowStory.args, label: "Option 3", value: "v-3" },
+		]
 }
 
 export const WithLabel = Template.bind({})
 WithLabel.args = {
-	name: 'my-radiogroup',
-	label: "My RadioGroup",
-	children: [<RadioRow {...row1args}/>, <RadioRow {...row2args} />, <RadioRow {...row3args} />]
+	name: "labelled-radiogroup",
+	selected: "v-1",
+	label: "Labelled RadioGroup",
+	items: 
+		[
+			{ ...RadioRowStory.args, label: "Option 1", value: "v-1" },
+			{ ...RadioRowStory.args, label: "Option 2", value: "v-2" },
+			{ ...RadioRowStory.args, label: "Option 3", value: "v-3" },
+		]
 }
 
 export const Required = Template.bind({})
 Required.args = {
-	name: 'my-required-radiogroup',
-	label: "My Radiogroup – pick one!",
+	name: "required-radiogroup",
+	selected: "v-1",
+	label: "Required RadioGroup",
 	required: true,
-	selected: "v3",
-	children: [<RadioRow {...row1args}/>, <RadioRow {...row2args} />, <RadioRow {...row3args} />]
+	items: 
+		[
+			{ ...RadioRowStory.args, label: "Option 1", value: "v-1" },
+			{ ...RadioRowStory.args, label: "Option 2", value: "v-2" },
+			{ ...RadioRowStory.args, label: "Option 3", value: "v-3" },
+		]
 }
 
 export const Disabled = Template.bind({})
 Disabled.args = {
-	name: "my-disabled-radiogroup",
-	label: "Disabled Radiogroup",
+	name: "disabled-radiogroup",
+	selected: "v-1",
+	label: "Disabled RadioGroup",
 	disabled: true,
-	selected: "v1",
-	children: [<RadioRow {...row1args}/>, <RadioRow {...row2args} />, <RadioRow {...row3args} />]
+	items: 
+		[
+			{ ...RadioRowStory.args, label: "Option 1", value: "v-1" },
+			{ ...RadioRowStory.args, label: "Option 2", value: "v-2" },
+			{ ...RadioRowStory.args, label: "Option 3", value: "v-3" },
+		]
 }
+
 
 

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { SelectRow } from "./index.js"
-import { Default as DefaultSelectOption } from "../SelectOption/SelectOption.stories"
+import { SelectOption } from "../SelectOption/"
+import { Default as DefaultSelectOptionStory } from "../SelectOption/SelectOption.stories"
 
 export default {
   title: "Design System/Forms/SelectRow",
@@ -8,10 +9,10 @@ export default {
   argTypes: {},
 }
 
-const Template = (args) => (
+const Template = ({ items, ...args}) => (
 	<SelectRow {...args}>
-		{args.children.map((child, i) => (
-			<DefaultSelectOption {...child} key={`option-${i}`} />
+		{items.map((item, i) => (
+			<SelectOption {...item} key={`${i}`} />
 		))}
 	</SelectRow>
 )
@@ -19,31 +20,43 @@ const Template = (args) => (
 export const Default = Template.bind({})
 Default.args = {
 	label: "Select Row",
-	children: [DefaultSelectOption.args]
+	items: 
+		[
+			{ ...DefaultSelectOptionStory.args, value: "d-1", label: "Option 1" },
+			{ ...DefaultSelectOptionStory.args, value: "d-2", label: "Option 2" }
+		]
 }
 
 export const WithHelpText = Template.bind({})
 WithHelpText.args = {
-	name: "my-select",
 	label: "Select Row with Helptext",
-	helptext: "Oh so helpful helptext",
-	children: [DefaultSelectOption.args]
+	helptext: "Select one",
+	items: 
+		[
+			{ ...DefaultSelectOptionStory.args, value: "d-1", label: "Option 1" },
+			{ ...DefaultSelectOptionStory.args, value: "d-2", label: "Option 2" }
+		]
 }
 
 export const Required = Template.bind({})
 Required.args = {
-	name: "my-select",
 	label: "Required Select Row",
 	required: true,
-	children: [DefaultSelectOption.args]
+	items: 
+		[
+			{ ...DefaultSelectOptionStory.args, value: "d-1", label: "Option 1" },
+			{ ...DefaultSelectOptionStory.args, value: "d-2", label: "Option 2" }
+		]
 }
 
 export const Disabled = Template.bind({})
 Disabled.args = {
-	name: "disabled-select",
-	label: "Disabled Select Row",
-	children: [DefaultSelectOption.args],
+	label: "Required Select Row",
 	disabled: true,
-	required: true,
-	helptext: "Oh so helpful helptext"
+	items: 
+		[
+			{ ...DefaultSelectOptionStory.args, value: "d-1", label: "Option 1" },
+			{ ...DefaultSelectOptionStory.args, value: "d-2", label: "Option 2" }
+		]
 }
+


### PR DESCRIPTION
rework nested stories so the actual Component name of child components shows up in storybook code samples (instead of 'bound component').