### PR TITLE
Icon clickable

### DIFF
--- a/libs/juno-ui-components/src/components/Button/Button.stories.js
+++ b/libs/juno-ui-components/src/components/Button/Button.stories.js
@@ -165,5 +165,5 @@ LinkAsButtonWithIcon.args = {
   ...Primary.args,
   icon: "warning",
   label: "Link as button with Icon",
-  href: "#link"
+  href: "#"
 }

--- a/libs/juno-ui-components/src/components/Icon/Icon.component.js
+++ b/libs/juno-ui-components/src/components/Icon/Icon.component.js
@@ -32,6 +32,24 @@ import Warning from "./icons/warning.svg"
 Generic Icon component.
 */
 
+const anchorIconStyles = `
+	text-current
+	focus:outline-none
+	focus:ring-2
+	focus:ring-theme-focus
+	disabled:opacity-50
+	disabled:cursor-not-allowed
+`
+
+const buttonIconStyles = `
+	inline-block
+	focus:outline-none
+	focus:ring-2
+	focus:ring-theme-focus
+	disabled:opacity-50
+	disabled:cursor-not-allowed
+`
+
 const getColoredSizedIcon = ({icon, color, size, title, className, ...props}) => {	
 		const iconClass = `juno-icon juno-icon-${icon} inline-block fill-current ${color} ${className || ""}`
 	  switch (icon) {
@@ -94,9 +112,30 @@ export const Icon = ({
 	size,
 	title,
 	className,
+	href,
+	onClick,
 	...props
 }) => {
-	return ( getColoredSizedIcon({icon, color, size, title, className, ...props}) )
+	
+	const icn = ( 
+		getColoredSizedIcon({icon, color, size, title, className, ...props})
+	)
+	
+	const button = (
+		<button onClick={onClick} className={`juno-icon-button ${buttonIconStyles}`} >
+			{icn}
+		</button>
+	)
+	
+	const anchor = (
+		<a href={href} className={`juno-icon-link ${anchorIconStyles}`} >
+			{icn}
+		</a>
+	)
+	
+	/* render an <a> if href was passed, otherwise render button if onClick was passes, otherwise render plain icon: */
+	return ( href ? anchor : ( onClick ? button : icn))
+
 }
 
 Icon.propTypes = { 
@@ -137,6 +176,10 @@ Icon.propTypes = {
 	title: PropTypes.string,
 	/** A custom className */
 	className: PropTypes.string,
+	/** Optionally specify an href. This will render the Icon inside an <code><a></code> element with the given url. */
+	 href: PropTypes.string,
+	 /** Optionally specify a click handler. This will render the icon inside a <code><button></code> with the given handler.  */
+	 onClick: PropTypes.func,
 }
 
 Icon.defaultProps = {
@@ -144,5 +187,7 @@ Icon.defaultProps = {
 	color: "",
 	size: "24",
 	title: "",
-	className: ""
+	className: "",
+	href:"",
+	onClick: undefined,
 }

--- a/libs/juno-ui-components/src/components/Icon/Icon.stories.js
+++ b/libs/juno-ui-components/src/components/Icon/Icon.stories.js
@@ -208,4 +208,12 @@ IconAsLink.args = {
   title: "The Icon is a link"
 }
 
+export const IconAsButton = Template.bind({})
+IconAsButton.args = {
+  ...Default.args,
+  title: "The Icon is a button",
+  onClick: () => { console.log('click')},
+}
+
+
 

--- a/libs/juno-ui-components/src/components/Icon/Icon.stories.js
+++ b/libs/juno-ui-components/src/components/Icon/Icon.stories.js
@@ -200,3 +200,12 @@ Warning.args = {
   ...Default.args,
   icon: "warning"
 }
+
+export const IconAsLink = Template.bind({})
+IconAsLink.args = {
+  ...Default.args,
+  href: "#",
+  title: "The Icon is a link"
+}
+
+

--- a/libs/juno-ui-components/src/components/Icon/Icon.test.js
+++ b/libs/juno-ui-components/src/components/Icon/Icon.test.js
@@ -202,6 +202,34 @@ describe("Icon", () => {
     expect(screen.getByRole("img")).toHaveAttribute("title", "My custom title")
   })
   
+  test("renders an <a> element if href is passed as prop", async () => {
+    render(<Icon href="#" />)
+    expect(screen.getByRole("link")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveAttribute("href", "#")
+  })
+  
+  test("renders a <button> element if a click handler is passed", async () => {
+    const handleClick = jest.fn();
+    render(<Icon onClick={handleClick} />);
+    expect(screen.getByRole("button")).toBeInTheDocument()
+  })
+  
+  test('an onClick handler is called as passed', () => {
+    const handleClick = jest.fn();
+    render(<Icon onClick={handleClick} />);
+    screen.getByRole('button').click();
+    expect(handleClick).toHaveBeenCalled();
+  })
+  
+  test("renders an <a> element and ignore onClick handler if both href and onClick handler are passed", async () => {
+    const handleClick = jest.fn();
+    render(<Icon href="#" onClick={handleClick}/>)
+    expect(screen.getByRole("link")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveAttribute("href", "#")
+    screen.getByRole('link').click();
+    expect(handleClick).not.toHaveBeenCalled();
+  })
+  
   // Test all props:
   
   test("renders all props as passed", async () => {


### PR DESCRIPTION
* Icon component now accepts `href` prop (will render `<a>`)
* Icon button now accepts `onClick` handler as prop (will render `<button>`)
* In case both are passed `href` will trump `onClick` (can be changed later if sensible)
* ClickableIcon component still exists because legacy usage in apps
