### PR TITLE
[ui] render children as children and text in a p element

### DIFF
--- a/libs/juno-ui-components/src/components/IntroBox/IntroBox.component.js
+++ b/libs/juno-ui-components/src/components/IntroBox/IntroBox.component.js
@@ -73,7 +73,7 @@ export const IntroBox = ({
       <div className={`${introboxBorder}`}></div>
       <div className={`${introboxContent(variant, heroImage)}`}>
         {title ? <h1 className={`${introboxHeading}`}>{title}</h1> : ""}
-        <p>{children ? children : text}</p>
+        {children ? children : <p>{text}</p>}
       </div>
     </div>
   )

--- a/libs/juno-ui-components/src/components/IntroBox/IntroBox.test.js
+++ b/libs/juno-ui-components/src/components/IntroBox/IntroBox.test.js
@@ -43,9 +43,14 @@ describe("IntroBox", () => {
     render(
       <IntroBox data-testid="my-introbox" text="My IntroBox text goes here." />
     )
-    expect(screen.getByTestId("my-introbox")).toHaveTextContent(
-      "My IntroBox text goes here."
-    )
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === "p" &&
+          content.startsWith("My IntroBox text goes here.")
+        )
+      })
+    ).toBeTruthy()
   })
 
   test("renders a custom class as passed", async () => {
@@ -53,15 +58,20 @@ describe("IntroBox", () => {
     expect(screen.getByTestId("my-introbox")).toHaveClass("my-custom-class")
   })
 
-  test("renders text as passed as children", async () => {
+  test("renders children passed as children", async () => {
     render(
       <IntroBox data-testid="my-introbox">
-        {"My Introbox children text goes here!"}
+        <div>My Introbox text in a div goes here!</div>
       </IntroBox>
     )
-    expect(screen.getByTestId("my-introbox")).toHaveTextContent(
-      "My Introbox children text goes here!"
-    )
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === "div" &&
+          content.startsWith("My Introbox text in a div goes here!")
+        )
+      })
+    ).toBeTruthy()
   })
 
   test("renders text as passed as children if both children and 'text' prop were passed", async () => {


### PR DESCRIPTION
avoid `<div> cannot appear as a descendant of <p>.`