### PR TITLE
[oauth] silent default false

### DIFF
--- a/libs/oauth/src/useOidcAuth.js
+++ b/libs/oauth/src/useOidcAuth.js
@@ -167,7 +167,7 @@ const useOidcAuth = (options) => {
   const logout = useCallback(
     (options) => {
       if (options?.resetOIDCSession)
-        oidcLogout(issuerURL, { silent: options.silent !== false })
+        oidcLogout(issuerURL, { silent: options?.silent === true })
       else setAuth(null)
     },
     [setAuth]


### PR DESCRIPTION
before was `options.silent !== false` and this leads to silent to be true if the option is not being set. It should be silent when the user sets the option silent to TRUE, everything else (also `undefined`) should be false.