### PR TITLE
[ui] added callback on dismiss

### DIFF
--- a/libs/juno-ui-components/src/components/Message/Message.component.js
+++ b/libs/juno-ui-components/src/components/Message/Message.component.js
@@ -228,5 +228,6 @@ Message.defaultProps = {
   dismissible: false,
   autoDismiss: false,
   autoDismissTimeout: 10000,
+  onDismiss: undefined,
   className: "",
 }

--- a/libs/juno-ui-components/src/components/Message/Message.component.js
+++ b/libs/juno-ui-components/src/components/Message/Message.component.js
@@ -134,6 +134,7 @@ export const Message = ({
   dismissible,
   autoDismiss,
   autoDismissTimeout,
+  onDismiss,
   className,
   children,
   ...props
@@ -151,15 +152,14 @@ export const Message = ({
   useEffect(() => {
     if (autoDismiss) {
       clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(
-        () => setVisible(false),
-        autoDismissTimeout
-      )
+      timeoutRef.current = setTimeout(() => hideMessage(), autoDismissTimeout)
     }
   }, [autoDismiss, autoDismissTimeout])
 
   const hideMessage = () => {
     setVisible(false)
+    // call the callback dismiss message (if any)
+    onDismiss && onDismiss()
   }
 
   return (
@@ -213,6 +213,8 @@ Message.propTypes = {
   autoDismiss: PropTypes.bool,
   /** Optional. Timeout in miliseconds after which the message is automatically dismissed. By default 10000 (10s).*/
   autoDismissTimeout: PropTypes.number,
+  /** Optional. Pass a handler that will be called when the message is dismissed */
+  onDismiss: PropTypes.func,
   /** Pass an optional className */
   className: PropTypes.string,
   /** Pass child nodes to be rendered as contents */

--- a/libs/juno-ui-components/src/components/Message/Message.test.js
+++ b/libs/juno-ui-components/src/components/Message/Message.test.js
@@ -32,6 +32,25 @@ describe("Message", () => {
     })
   })
 
+  test("fires onDismiss handler when Message is manually dismissed", async () => {
+    const handleDismiss = jest.fn()
+    render(
+      <Message
+        data-testid="my-message"
+        dismissible={true}
+        onDismiss={handleDismiss}
+      />
+    )
+    // not checking specifically for the close button here. So if there is more than one button in the message this test will fail
+    // The reason is that it's hard to find specifically the close button because any classes added to a clickable Icon go to the image element, not the surrounding button
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    userEvent.click(screen.getByRole("button"))
+    await waitFor(() => {
+      expect(screen.queryByTestId("my-message")).not.toBeInTheDocument()
+      expect(handleDismiss).toHaveBeenCalledTimes(1)
+    })
+  })
+
   test("renders a Message without dismiss button by default", async () => {
     render(<Message data-testid="my-message" />)
     expect(screen.queryByRole("button")).not.toBeInTheDocument()
@@ -58,22 +77,7 @@ describe("Message", () => {
     )
   })
 
-  // const handleChange = jest.fn()
-  // render(<TextareaRow onChange={handleChange} />)
-  // const textarea = screen.getByRole("textbox")
-  // fireEvent.change(textarea, { target: { value: "test value a" } })
-  // expect(handleChange).toHaveBeenCalledTimes(1)
-  // expect(handleChange).toHaveBeenCalledWith(
-  // 	expect.objectContaining({
-  // 		_reactName: "onChange",
-  // 		target: expect.objectContaining({
-  // 			value: "test value a",
-  // 		}),
-  // 		type: "change",
-  // 	})
-  // )
-
-  test("fires onDismiss handler when Message is dismissed", async () => {
+  test("fires onDismiss handler when Message is automatically dismissed", async () => {
     const handleDismiss = jest.fn()
     render(
       <Message

--- a/libs/juno-ui-components/src/components/Message/Message.test.js
+++ b/libs/juno-ui-components/src/components/Message/Message.test.js
@@ -58,6 +58,40 @@ describe("Message", () => {
     )
   })
 
+  // const handleChange = jest.fn()
+  // render(<TextareaRow onChange={handleChange} />)
+  // const textarea = screen.getByRole("textbox")
+  // fireEvent.change(textarea, { target: { value: "test value a" } })
+  // expect(handleChange).toHaveBeenCalledTimes(1)
+  // expect(handleChange).toHaveBeenCalledWith(
+  // 	expect.objectContaining({
+  // 		_reactName: "onChange",
+  // 		target: expect.objectContaining({
+  // 			value: "test value a",
+  // 		}),
+  // 		type: "change",
+  // 	})
+  // )
+
+  test("fires onDismiss handler when Message is dismissed", async () => {
+    const handleDismiss = jest.fn()
+    render(
+      <Message
+        data-testid="my-message"
+        autoDismiss={true}
+        autoDismissTimeout={500}
+        onDismiss={handleDismiss}
+      />
+    )
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId("my-message")).not.toBeInTheDocument()
+        expect(handleDismiss).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 1000 }
+    )
+  })
+
   test("renders an info Message as passed", async () => {
     render(<Message data-testid="my-message" variant="info" />)
     expect(screen.getByTestId("my-message")).toHaveClass("juno-message-info")


### PR DESCRIPTION
Allow get notified when a message is manually or automatically dismissed. This helps when cleaning up states where the messaged are mantained.