### PR TITLE
Fix filters

### DIFF
--- a/libs/juno-ui-components/src/components/FilterInput/FilterInput.component.js
+++ b/libs/juno-ui-components/src/components/FilterInput/FilterInput.component.js
@@ -46,6 +46,7 @@ export const FilterInput = ({
 	selectedFilterKey,
 	onSelectedFilterKeyChange,
 	filterValue,
+	valuePlaceholder,
 	onFilterValueChange,
 	onClear,
 	onKeyPress,
@@ -133,7 +134,7 @@ export const FilterInput = ({
 				onChange={handleFilterValueChange}
 				onKeyPress={handleKeyPress}
 				disabled={isLoading}
-				placeholder={ isLoading ? "Loading Filter Options…" : null }
+				placeholder={ isLoading ? "Loading Filter Options…" : valuePlaceholder }
 			/>
 			<div className={`${iconWrapperStyles}`}>
 				{ value && value.length ?
@@ -162,6 +163,8 @@ FilterInput.propTypes = {
 	valueLabel: PropTypes.string, // TODO -> valueLabel
 	/** The current value of the Filter Input */
 	filterValue: PropTypes.string,
+	/** Optional: pass a placeholder for the filter value text input */
+	valuePlaceholder: PropTypes.string,
 	/** Pass a handler to be executed when the filter value changes */
 	onFilterValueChange: PropTypes.func,
 	/** Pass a handler to execute when the Filter Value Clear button is clicked */
@@ -181,6 +184,7 @@ FilterInput.defaultProps = {
 	onSelectedFilterKeyChange: undefined,
 	valueLabel: "Filter by Value",
 	filterValue: "",
+	valuePlaceholder: "",
 	onFilterValueChange: undefined,
 	onClear: undefined,
 	onFilter: undefined,

--- a/libs/juno-ui-components/src/components/FilterInput/FilterInput.stories.js
+++ b/libs/juno-ui-components/src/components/FilterInput/FilterInput.stories.js
@@ -11,6 +11,7 @@ const Template = (args) => <FilterInput {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
+	valuePlaceholder: "Enter a value",
 	options: [
 		{label: "Filter 1", key: "filter-1"},
 		{label: "Filter 2", key: "filter-2", disabled: true},

--- a/libs/juno-ui-components/src/components/FilterInput/FilterInput.test.js
+++ b/libs/juno-ui-components/src/components/FilterInput/FilterInput.test.js
@@ -53,6 +53,12 @@ describe("FilterInput", () => {
 		expect(screen.getByRole("textbox")).toHaveAttribute("aria-label", "my value input")
 	})
 	
+	test("renders a text input with a placeholder as passed", async () => {
+		render(<FilterInput options={[{label: "option 1", value: "option-1", disabled: true}, {label: "option 2", value: "option-2"}]} valuePlaceholder={"my value placeholder"}/>)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("placeholder", "my value placeholder")
+	})
+	
 	test("renders a selected filter as passed", async () => {
 		const filterOptions = [{label: "OS", value: "byOs"}, {label: "Region", value: "byRegion"}]
 		render(<FilterInput options={filterOptions} selectedFilterKey="byRegion" />)

--- a/libs/juno-ui-components/src/components/Filters/Filters.component.js
+++ b/libs/juno-ui-components/src/components/Filters/Filters.component.js
@@ -35,6 +35,7 @@ export const Filters = ({
 	selectedFilterKey,
 	onSelectedFilterKeyChange,
 	filterValue,
+	valuePlaceholder,
 	onFilterValueChange,
 	onFilter,
 	onFilterClear,
@@ -54,6 +55,7 @@ export const Filters = ({
 						selectedFilterKey={selectedFilterKey}
 						onSelectedFilterKeyChange={onSelectedFilterKeyChange}
 						filterValue={filterValue}
+						valuePlaceholder={valuePlaceholder}
 						onFilterValueChange={onFilterValueChange}
 						onFilter={onFilter}
 						onClear={onFilterClear}
@@ -89,6 +91,8 @@ Filters.propTypes = {
 	onSelectedFilterKeyChange: PropTypes.func,
 	/** The value of the FilterInput */
 	filterValue: PropTypes.string,
+	/** Optional: Pass a placeholder for the filter value text input */
+	valuePlaceholder: PropTypes.string,
 	/** Pass a handler to be executed whenever the value of the filter value input changes */
 	onFilterValueChange: PropTypes.func,  
 	/** Pass a handler to be executed once the user clicks the filter button */
@@ -107,6 +111,7 @@ Filters.defaultProps = {
 	selectedFilterKey: "",
 	onSelectedFilterKeyChange: undefined,
 	filterValue: "",
+	valuePlaceholder: "",
 	onFilter: undefined,
 	onFilterValueChange: undefined,
 	onFilterClear: undefined,

--- a/libs/juno-ui-components/src/components/Filters/Filters.stories.js
+++ b/libs/juno-ui-components/src/components/Filters/Filters.stories.js
@@ -30,7 +30,7 @@ const PillsTemplate = (args) => <Filters {...args}>
 export const Default = Template.bind({})
 Default.args = {
   filters: {
-    label: "Select a Filter",
+    keyLabel: "Select a Filter",
     options: [
       {label: "Filter 1", key: "filter-1"}
     ]
@@ -40,7 +40,7 @@ Default.args = {
 export const Loading = Template.bind({})
 Loading.args = {
   filters: {
-    label: "Select a Filter",
+    keyLabel: "Select a Filter",
     options: []
   },
   loading: true

--- a/libs/juno-ui-components/src/components/Filters/Filters.stories.js
+++ b/libs/juno-ui-components/src/components/Filters/Filters.stories.js
@@ -29,6 +29,7 @@ const PillsTemplate = (args) => <Filters {...args}>
 
 export const Default = Template.bind({})
 Default.args = {
+  valuePlaceholder: "Enter a value",
   filters: {
     keyLabel: "Select a Filter",
     options: [

--- a/libs/juno-ui-components/src/components/Filters/Filters.test.js
+++ b/libs/juno-ui-components/src/components/Filters/Filters.test.js
@@ -41,6 +41,13 @@ describe("Filters", () => {
 
 	})
 	
+	test("renders a Filter vlaue text input witn a placeholder as passed", async () => {
+		const filters = {valueLabel: "Enter a filter value", options: [{label: "option 1", value: "option-1"}, {label: "option 2", value: "option-2"}]}
+		render(<Filters valuePlaceholder="my placeholder" filters={filters} />)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("placeholder", "my placeholder")
+	})
+	
 	test("renders a Filter value as passed", async () => {
 		const filters = {options: [{label: "option 1", value: "option-1"}]}
 		render(<Filters filters={filters} filterValue="abc" />)


### PR DESCRIPTION
* FilterInput now accepts a `valuePlaceholder` prop as a string that will render as a placeholder in the filter value text input (as long as the component is not loading)
* fixed some stories: the correct name `keyLabel` of the prop to render as the default option in the filter key select element is now represented in all stories