### PR TITLE
[ui] Breadcrumb: fix key error

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "lib/esm/styles.css",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "files": [
     "src",
     "lib",

--- a/libs/juno-ui-components/src/components/Breadcrumb/Breadcrumb.component.js
+++ b/libs/juno-ui-components/src/components/Breadcrumb/Breadcrumb.component.js
@@ -8,31 +8,27 @@ const breadcrumbstyles = `
 
 `
 /** Generic breadcrumb component. Use this to Wrap `Breadcrumb` items or custom children in a breadcrumb. */
-export const Breadcrumb = ({
-  children,
-  className,
-  ...props
-}) => {
-  
+export const Breadcrumb = ({ children, className, ...props }) => {
   const breadcrumbArray = Children.toArray(children)
   const breadcrumbArrayWithSeparators = []
-  
-  breadcrumbArray.forEach( (child, i) => {
+
+  breadcrumbArray.forEach((child, i) => {
     breadcrumbArrayWithSeparators.push(
-      <>
-        <BreadcrumbItem {...child.props} key={i} />
-        { i < breadcrumbArray.length - 1 ?
-            <Icon icon="chevronRight" />
-          :
-            null
-        }
-      </>
+      <React.Fragment key={i}>
+        <BreadcrumbItem {...child.props} />
+        {i < breadcrumbArray.length - 1 ? <Icon icon="chevronRight" /> : null}
+      </React.Fragment>
     )
   })
-  
+
   return (
-    <Stack className={`juno-breadcrumb ${breadcrumbstyles} ${className}`} gap="1" {...props} >
-      { breadcrumbArrayWithSeparators }
+    <Stack
+      className={`juno-breadcrumb ${breadcrumbstyles} ${className}`}
+      gap="1"
+      key="stck"
+      {...props}
+    >
+      {breadcrumbArrayWithSeparators}
     </Stack>
   )
 }


### PR DESCRIPTION
use `React.Fragment` with key instead of unkeyed `<>`