### PR TITLE
Selectrow placeholder

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.component.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.component.js
@@ -58,6 +58,7 @@ export const SelectRow = ({
   invalid,
   errortext,
   valid,
+  placeholder,
   successtext,
   children,
   value,
@@ -135,6 +136,7 @@ export const SelectRow = ({
           labelClassName={ variant === "floating" ? "jn-pt-[0.8125rem]" : "" }
           name={name}
           id={id}
+          placeholder={placeholder}
           onValueChange={onValueChange || onChange}
           onOpenChange={onOpenChange}
           disabled={disabled}
@@ -168,6 +170,8 @@ SelectRow.propTypes = {
   variant: PropTypes.oneOf(["floating", "stacked"]),
   /** Label text */
   label: PropTypes.string,
+  /** The placeholder to show in the Select if no value is selected. defaults to "Select…". */
+  placeholder: PropTypes.string,
   /** Id */
   id: PropTypes.string,
   /** Help text */
@@ -206,6 +210,7 @@ SelectRow.defaultProps = {
   name: null,
   variant: "floating",
   label: null,
+  placeholder: "Select…",
   id: null,
   required: null,
   className: "",

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
@@ -66,10 +66,11 @@ Controlled.args = {
   ]
 }
 
-export const WithHelpText = Template.bind({})
-WithHelpText.args = {
-  label: "Select Row with Helptext",
+export const WithHelpTextAndPlaceholder = Template.bind({})
+WithHelpTextAndPlaceholder.args = {
+  label: "Select Row with Helptext and placeholder",
   helptext: "Select one",
+  placeholder: "Select an option…", 
   items: [
     { ...DefaultSelectOptionStory.args, value: "d-1", label: "Option 1" },
     { ...DefaultSelectOptionStory.args, value: "d-2", label: "Option 2" },

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.test.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.test.js
@@ -70,6 +70,12 @@ describe("SelectRow", () => {
 		expect(screen.getByTestId("select-row")).toHaveClass("my-custom-class")
 	})
 	
+	test("renders a placeholder in the Select as passed", async () => {
+		render(<SelectRow placeholder="my placeholder" />)
+		expect(screen.getByRole("combobox")).toBeInTheDocument()
+		expect(screen.getByRole("combobox")).toHaveTextContent("my placeholder")
+	})
+	
 	test("renders a disabled select as passed", async () => {
 		render(<SelectRow disabled />)
 		expect(screen.getByRole("combobox")).toBeInTheDocument()


### PR DESCRIPTION
Adds an explicit `placeholder` prop to `SelectRow` to render in the contained Select when there's no option/value selected.