### PR TITLE
Pass forward refs

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/SelectDivider/SelectDivider.component.js
+++ b/libs/juno-ui-components/src/components/SelectDivider/SelectDivider.component.js
@@ -12,7 +12,7 @@ const dividerStyles = `
 export const SelectDivider = React.forwardRef(
   ({className, ...props}, forwardedRef) => {
     return (
-      <div className={`juno-select-divider ${dividerStyles} ${className}`} {...props}></div>
+      <div className={`juno-select-divider ${dividerStyles} ${className}`} ref={forwardedRef} {...props}></div>
     )
   }
 )

--- a/libs/juno-ui-components/src/components/SelectOptionGroup/SelectOptionGroup.component.js
+++ b/libs/juno-ui-components/src/components/SelectOptionGroup/SelectOptionGroup.component.js
@@ -13,7 +13,7 @@ const labelStyles = `
 export const SelectOptionGroup = React.forwardRef(
   ({children, label, className, ...props}, forwardedRef) => {
     return (
-      <RadixSelect.Group className={`juno-select-option-group ${className}`} {...props}>
+      <RadixSelect.Group className={`juno-select-option-group ${className}`} ref={forwardedRef} {...props}>
         { label ? 
             <RadixSelect.Label className={`juno-select-group-label ${labelStyles}`}>{label}</RadixSelect.Label>
           :


### PR DESCRIPTION
In `SelectOptionGroup` and `SelectDivider`, the forwardedRef was not passed down as a ref inside the component, thus (presumably) causing React warnings. Pass `ref={forwardedRef}` added and version bumped to 1.5.6. to see whether this fixes the warnings.