### PR TITLE
Forms unique ids

### DIFF
--- a/libs/juno-ui-components/src/components/Checkbox/Checkbox.test.js
+++ b/libs/juno-ui-components/src/components/Checkbox/Checkbox.test.js
@@ -35,6 +35,7 @@ describe("Checkbox", () => {
 		render(<Checkbox />)
 		expect(screen.getByRole("checkbox")).toBeInTheDocument()
 		expect(screen.getByRole("checkbox")).toHaveAttribute('id')
+		expect(screen.getByRole("checkbox").getAttribute("id")).toMatch("juno-checkbox")
 	})
 	
 	test("renders a checkbox with a value as passed", async () => {

--- a/libs/juno-ui-components/src/components/Checkbox/Checkbox.test.js
+++ b/libs/juno-ui-components/src/components/Checkbox/Checkbox.test.js
@@ -38,6 +38,20 @@ describe("Checkbox", () => {
 		expect(screen.getByRole("checkbox").getAttribute("id")).toMatch("juno-checkbox")
 	})
 	
+	test("renders a Checkbox with an associated label with an id as passed", async () => {
+		render(<Checkbox id="my-checkbox" label="My Checkbox"/>)
+		expect(screen.getByRole("checkbox")).toBeInTheDocument()
+		expect(screen.getByLabelText("My Checkbox")).toBeInTheDocument()
+		expect(document.querySelector(".juno-label")).toBeInTheDocument()
+		expect(document.querySelector(".juno-label")).toHaveTextContent("My Checkbox")
+	})
+	
+	test("renders a Checkbox with a label associated by an auto-generated id if no id was passed ", async () => {
+		render(<Checkbox label="This is a Checkbox" />)
+		expect(screen.getByRole("checkbox")).toBeInTheDocument()
+		expect(screen.getByLabelText("This is a Checkbox")).toBeInTheDocument()
+	})
+	
 	test("renders a checkbox with a value as passed", async () => {
 		render(<Checkbox value="ValueAsPassed" />)
 		expect(screen.getByRole("checkbox")).toBeInTheDocument()

--- a/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.component.js
+++ b/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.component.js
@@ -212,9 +212,6 @@ export const CheckboxGroup = ({
           :
             ""
          }
-        <p>
-          selectedOptions: {selectedOptions}
-        </p>
       </div>
     </CheckboxGroupContext.Provider>
   )

--- a/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.test.js
+++ b/libs/juno-ui-components/src/components/CheckboxGroup/CheckboxGroup.test.js
@@ -13,7 +13,20 @@ describe("CheckboxGroup", () => {
 		expect(screen.getByTestId("checkbox-group")).toBeInTheDocument()
 	})
 	
-	test("renders a CheckboxGroup with a label as passed", async () => {
+	test("renders a CheckboxGroup with an id as passed ", async () => {
+		render(< CheckboxGroup data-testid="group" id="my-checkboxgroup-1"/>)
+		expect(screen.getByTestId("group")).toBeInTheDocument()
+		expect(screen.getByTestId("group")).toHaveAttribute("id", "my-checkboxgroup-1")
+	})
+	
+	test("renders a CheckboxGroup with an auto-generated id if no id is passed", async () => {
+		render(< CheckboxGroup data-testid="group"/>)
+		expect(screen.getByTestId("group")).toBeInTheDocument()
+		expect(screen.getByTestId("group")).toHaveAttribute("id")
+		expect(screen.getByTestId("group").getAttribute("id")).toMatch("juno-checkboxgroup")
+	})
+	
+	test("renders a CheckboxGroup with an associated label as passed", async () => {
 		render(
 			<CheckboxGroup name="my-checkboxgroup" label="My Group of Checkboxes"> 
 			</CheckboxGroup>

--- a/libs/juno-ui-components/src/components/Form/Form.stories.js
+++ b/libs/juno-ui-components/src/components/Form/Form.stories.js
@@ -9,9 +9,9 @@ import { SelectOption } from "../SelectOption/index.js"
 import { Switch } from "../Switch/index.js"
 import { Textarea } from "../Textarea/index.js"
 import { RadioGroup } from "../RadioGroup/index.js"
-import { RadioRow } from "../RadioRow/index.js"
+import { Radio } from "../Radio/index.js"
 import { CheckboxGroup } from "../CheckboxGroup/index.js"
-import { CheckboxRow } from "../CheckboxRow/index.js"
+import { Checkbox } from "../Checkbox/index.js"
 import { Button } from "../Button/index.js"
 import { ButtonRow } from "../ButtonRow/index.js"
 import { IntroBox } from "../IntroBox/index.js"
@@ -78,14 +78,14 @@ ComplexForm.args = {
     </FormSection>,
     <FormSection title="Second Section of the Form" key="fs-2">
       <RadioGroup name="color-radios" label="In case you are not sure, select your true favorite color:">
-        <RadioRow key="r-1" id="color-red" label="Red" value="red"/>
-        <RadioRow key="r-2" id="color-blue" label="Blue" value="blue"/>
-        <RadioRow key="r-3" id="color-green" label="Green" value="green"/>
-        <RadioRow key="r-4" id="color-yellow" label="Yellow" value="yellow"/>
+        <Radio key="r-1" id="color-red" label="Red" value="red"/>
+        <Radio key="r-2" id="color-blue" label="Blue" value="blue"/>
+        <Radio key="r-3" id="color-green" label="Green" value="green"/>
+        <Radio key="r-4" id="color-yellow" label="Yellow" value="yellow"/>
       </RadioGroup>
       <CheckboxGroup name="all-about-red" label="What is your opinion towards the color Red?">
-        <CheckboxRow key="c-1" id="overrated" label="Red is vastly overrated" value="overrated"/>
-        <CheckboxRow key="c-2" id="blackisred" label="Black is better" value="blackisbetter"/>
+        <Checkbox key="c-1" id="overrated" label="Red is vastly overrated" value="overrated"/>
+        <Checkbox key="c-2" id="blackisred" label="Black is better" value="blackisbetter"/>
       </CheckboxGroup>
       <FormRow key="fr-4">
         <Textarea label="Your Message" id="message" placeholder="If there is something else we should know about you – now is the time!"/>

--- a/libs/juno-ui-components/src/components/Radio/Radio.test.js
+++ b/libs/juno-ui-components/src/components/Radio/Radio.test.js
@@ -38,6 +38,20 @@ describe("Radio", () => {
 		expect(screen.getByRole("radio").getAttribute("id")).toMatch("juno-radio")
 	})
 	
+	test("renders a Radio with an associated label with an id as passed", async () => {
+		render(<Radio id="my-radio" label="My Radio"/>)
+		expect(screen.getByRole("radio")).toBeInTheDocument()
+		expect(screen.getByLabelText("My Radio")).toBeInTheDocument()
+		expect(document.querySelector(".juno-label")).toBeInTheDocument()
+		expect(document.querySelector(".juno-label")).toHaveTextContent("My Radio")
+	})
+	
+	test("renders a Radio with a label associated by an auto-generated id if no id was passed ", async () => {
+		render(<Radio label="This is a Radio" />)
+		expect(screen.getByRole("radio")).toBeInTheDocument()
+		expect(screen.getByLabelText("This is a Radio")).toBeInTheDocument()
+	})
+	
 	test("renders a radio with a value as passed", async () => {
 		render(<Radio value="ValueAsPassed" />)
 		expect(screen.getByRole("radio")).toBeInTheDocument()

--- a/libs/juno-ui-components/src/components/Radio/Radio.test.js
+++ b/libs/juno-ui-components/src/components/Radio/Radio.test.js
@@ -35,6 +35,7 @@ describe("Radio", () => {
 		render(<Radio />)
 		expect(screen.getByRole("radio")).toBeInTheDocument()
 		expect(screen.getByRole("radio")).toHaveAttribute('id')
+		expect(screen.getByRole("radio").getAttribute("id")).toMatch("juno-radio")
 	})
 	
 	test("renders a radio with a value as passed", async () => {

--- a/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
+++ b/libs/juno-ui-components/src/components/RadioGroup/RadioGroup.test.js
@@ -47,7 +47,20 @@ describe("RadioGroup", () => {
 		radios.forEach( radio => expect(radio).toHaveAttribute('name') )
 	})
 	
-    test("renders a label for the group as passed", async () => {
+	test("renders a RadioGroup with an id as passed", async () => {
+		render(<RadioGroup data-testid="group" id="my-radiogroup" />)
+		expect(screen.getByTestId("group")).toBeInTheDocument()
+		expect(screen.getByTestId("group")).toHaveAttribute("id", "my-radiogroup")
+	})
+	
+	test("renders a RadioGroup with an auto-generated id if no id is passed", async () => {
+		render(< RadioGroup data-testid="group"/>)
+		expect(screen.getByTestId("group")).toBeInTheDocument()
+		expect(screen.getByTestId("group")).toHaveAttribute("id")
+		expect(screen.getByTestId("group").getAttribute("id")).toMatch("juno-radiogroup")
+	})
+	
+  test("renders a label for the group as passed", async () => {
 		render(
 			<RadioGroup name="my-radiogroup" label="My labeled RadioGroup" >
 				<Radio />

--- a/libs/juno-ui-components/src/components/Select/Select.component.js
+++ b/libs/juno-ui-components/src/components/Select/Select.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useState, useEffect, useMemo, useId } from "react"
 import * as RadixSelect from "@radix-ui/react-select"
 import { Label } from "../Label/index"
 import { Icon } from "../Icon/index.js"
@@ -125,6 +125,10 @@ export const Select = React.forwardRef(
       return !(typeof str === 'string' && str.trim().length === 0)
     }
     
+    const uniqueId = () => (
+      "juno-select-" + useId()
+    )
+    
     const [isOpen, setIsOpen] = useState(false)
     const [hasError, setHasError] = useState(false)
     const [isInvalid, setIsInvalid] = useState(false)
@@ -190,6 +194,8 @@ export const Select = React.forwardRef(
       }
     }
     
+    const theId = id || uniqueId()
+    
     return (
       <div>
         <span 
@@ -205,7 +211,7 @@ export const Select = React.forwardRef(
             label && isNotEmptyString(label) ?
               <Label 
                 text={label}
-                htmlFor={id}
+                htmlFor={theId}
                 className={`${labelStyles}`}
                 disabled={disabled}
                 required={required}
@@ -226,7 +232,7 @@ export const Select = React.forwardRef(
             defaultValue={defaultValue}
           >
             <RadixSelect.Trigger 
-              id={id}
+              id={theId}
               aria-label={ariaLabel}
               className={`
                 juno-select

--- a/libs/juno-ui-components/src/components/Select/Select.test.js
+++ b/libs/juno-ui-components/src/components/Select/Select.test.js
@@ -52,7 +52,20 @@ describe("Select", () => {
     expect(document.querySelector(".juno-label")).toHaveTextContent("My Label")
   })
   
-  test("redners a required marker as passed", async () => {
+  test("renders an id as passed", async () => {
+    render(<Select id="select-1" />)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toHaveAttribute("id", "select-1")
+  })
+  
+  test("renders a generated unique id if no id was passed", async () => {
+    render(<Select />)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toHaveAttribute("id")
+    expect(screen.getByRole("combobox").getAttribute("id")).toMatch("juno-select")
+  })
+  
+  test("renders a required marker as passed", async () => {
     render(<Select label="My Label" required={true} />)
     expect(screen.getByRole("combobox")).toBeInTheDocument()
     expect(document.querySelector(".juno-required")).toBeInTheDocument()

--- a/libs/juno-ui-components/src/components/Select/Select.test.js
+++ b/libs/juno-ui-components/src/components/Select/Select.test.js
@@ -44,25 +44,37 @@ describe("Select", () => {
     expect(screen.getByRole("combobox")).toHaveClass("juno-select")
   })
   
-  test("renders a label as passed", async () => {
+  test("renders a Select with a label as passed", async () => {
     render(<Select label="My Label" id="my-select"/>)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByLabelText("My Label")).toBeInTheDocument()
     expect(document.querySelector(".juno-label")).toBeInTheDocument()
     expect(document.querySelector(".juno-label")).toHaveTextContent("My Label")
   })
   
-  test("renders an id as passed", async () => {
+  test("renders a Select with an id as passed", async () => {
     render(<Select id="select-1" />)
     expect(screen.getByRole("combobox")).toBeInTheDocument()
     expect(screen.getByRole("combobox")).toHaveAttribute("id", "select-1")
   })
   
-  test("renders a generated unique id if no id was passed", async () => {
+  test("renders Select with a generated unique id if no id was passed", async () => {
     render(<Select />)
     expect(screen.getByRole("combobox")).toBeInTheDocument()
     expect(screen.getByRole("combobox")).toHaveAttribute("id")
     expect(screen.getByRole("combobox").getAttribute("id")).toMatch("juno-select")
+  })
+  
+  test("renders a Select with an associated label with an id as passed", async () => {
+    render(<Select id="my-select" label="My Select"/>)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByLabelText("My Select")).toBeInTheDocument()
+    expect(document.querySelector(".juno-label")).toBeInTheDocument()
+    expect(document.querySelector(".juno-label")).toHaveTextContent("My Select")
+  })
+  
+  test("renders a Select with a label associated by an auto-generated id if no id was passed ", async () => {
+    render(<Select label="This is a Select" />)
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByLabelText("This is a Select")).toBeInTheDocument()
   })
   
   test("renders a required marker as passed", async () => {

--- a/libs/juno-ui-components/src/components/Switch/Switch.component.js
+++ b/libs/juno-ui-components/src/components/Switch/Switch.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useState, useEffect, useMemo, useId } from "react"
 import PropTypes from "prop-types"
 import { Label } from "../Label/index"
 import { Icon } from "../Icon/index"
@@ -128,6 +128,10 @@ export const Switch = ({
 		return !(typeof str === 'string' && str.trim().length === 0)
 	}
 	
+	const uniqueId = () => (
+		"juno-switch-" + useId()
+	)
+	
 	const [isOn, setIsOn] = useState(on)
 	const [isInvalid, setIsInvalid] = useState(false)
 	const [isValid, setIsValid] = useState(false)
@@ -159,6 +163,8 @@ export const Switch = ({
 		onChange && onChange(event)
 	}
 	
+	const theId = id || uniqueId()
+	
 	return (
 		<div>
 			<span className={`
@@ -170,7 +176,7 @@ export const Switch = ({
 					type="button"
 					role="switch"
 					name={name}
-					id={id}
+					id={theId}
 					aria-checked={isOn}
 					disabled={disabled}
 					onClick={handleClick}
@@ -190,7 +196,7 @@ export const Switch = ({
 				
 				<Label 
 					text={label}
-					htmlFor={id}
+					htmlFor={theId}
 					className="jn-ml-2"
 					disabled={disabled}
 					required={required}

--- a/libs/juno-ui-components/src/components/Switch/Switch.test.js
+++ b/libs/juno-ui-components/src/components/Switch/Switch.test.js
@@ -22,6 +22,13 @@ describe("Switch", () => {
     expect(screen.getByRole("switch")).toHaveAttribute('id', "my-switch")
   })
   
+  test("renders a switch with an auto-generated id if no id is passed", async () => {
+    render(<Switch /> )
+    expect(screen.getByRole("switch")).toBeInTheDocument()
+    expect(screen.getByRole("switch")).toHaveAttribute("id")
+    expect(screen.getByRole("switch").getAttribute("id")).toMatch("juno-switch")
+  })
+  
   test("renders a Switch with an associated label as passed", async () => {
     render(<Switch id="my-switch" label="My Switch"/>)
     expect(screen.getByRole("switch")).toBeInTheDocument()

--- a/libs/juno-ui-components/src/components/Switch/Switch.test.js
+++ b/libs/juno-ui-components/src/components/Switch/Switch.test.js
@@ -29,12 +29,18 @@ describe("Switch", () => {
     expect(screen.getByRole("switch").getAttribute("id")).toMatch("juno-switch")
   })
   
-  test("renders a Switch with an associated label as passed", async () => {
+  test("renders a Switch with an associated label with an id as passed", async () => {
     render(<Switch id="my-switch" label="My Switch"/>)
     expect(screen.getByRole("switch")).toBeInTheDocument()
     expect(screen.getByLabelText("My Switch")).toBeInTheDocument()
     expect(document.querySelector(".juno-label")).toBeInTheDocument()
     expect(document.querySelector(".juno-label")).toHaveTextContent("My Switch")
+  })
+  
+  test("renders a Switch with a label associated by an auto-generated id if no id was passed ", async () => {
+    render(<Switch label="This is a Switch" />)
+    expect(screen.getByRole("switch")).toBeInTheDocument()
+    expect(screen.getByLabelText("This is a Switch")).toBeInTheDocument()
   })
   
   test("renders a disabled switch as passed", async () => {

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.component.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react"
+import React, { useState, useEffect, useMemo, useId, useRef } from "react"
 import PropTypes from "prop-types"
 import { Label } from "../Label/index"
 import { Icon } from "../Icon/index"
@@ -106,6 +106,10 @@ export const TextInput = ({
     return !(typeof str === 'string' && str.trim().length === 0)
   }
   
+  const uniqueId = () => (
+    "juno-textinput-" + useId()
+  )
+  
   const ref = useRef()
   const [val, setValue] = useState("")
   const [hasFocus, setFocus] = useState(false)
@@ -176,6 +180,8 @@ export const TextInput = ({
     }
   }
   
+  const theId = id || uniqueId()
+  
   return (
     <div>
       <span 
@@ -189,7 +195,7 @@ export const TextInput = ({
         { label && label.length ?
             <Label 
               text={label}
-              htmlFor={id}
+              htmlFor={theId}
               className={`${labelStyles}`}
               disabled={disabled}
               required={required}
@@ -204,7 +210,7 @@ export const TextInput = ({
           name={name}
           autoComplete={autoComplete}
           value={val}
-          id={id}
+          id={theId}
           ref={ref}
           placeholder={placeholder}
           disabled={disabled}

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
@@ -25,8 +25,6 @@ describe("TextInput", () => {
 	
 	test("renders a label as passed", async () => {
 		render(<TextInput label="The Label" id="my-textinput"/>)
-		// implicitly test whether the input element can be selected via the labels text:
-		expect(screen.getByLabelText("The Label")).toBeInTheDocument()
 		expect(document.querySelector(".juno-label")).toBeInTheDocument()
 		expect(document.querySelector(".juno-label")).toHaveTextContent("The Label")
 	})
@@ -42,6 +40,20 @@ describe("TextInput", () => {
 		expect(screen.getByRole("textbox")).toBeInTheDocument()
 		expect(screen.getByRole("textbox")).toHaveAttribute("id")
 		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textinput")
+	})
+	
+	test("renders a text input with a label associated by an id as passed", async () => {
+		render(<TextInput label="TextInput goes here" id="ti-1"/>)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("id")
+		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ti-1")
+		expect(screen.getByLabelText("TextInput goes here")).toBeInTheDocument()
+	})
+	
+	test("renders a text input with a label associated by an auto-generated id if no id was passed ", async () => {
+		render(<TextInput label="This is a TextInput" />)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByLabelText("This is a TextInput")).toBeInTheDocument()
 	})
 	
 	test("renders a placeholder as passed", async () => {

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
@@ -37,6 +37,13 @@ describe("TextInput", () => {
 		expect(screen.getByRole("textbox")).toHaveAttribute('id', "my-textinput")
 	})
 	
+	test("renders a text input with an auto-generated id if no id is passed", async () => {
+		render(<TextInput />)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("id")
+		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textinput")
+	})
+	
 	test("renders a placeholder as passed", async () => {
 		render(<TextInput placeholder="my placeholder" />)
 		expect(screen.getByRole("textbox")).toBeInTheDocument()

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.component.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react"
+import React, { useState, useEffect, useMemo, useId, useRef } from "react"
 import PropTypes from "prop-types"
 import { Label } from "../Label/index"
 import { Icon } from "../Icon/index"
@@ -105,6 +105,10 @@ export const Textarea = ({
     return !(typeof str === 'string' && str.trim().length === 0)
   }
   
+  const uniqueId = () => (
+    "juno-textarea-" + useId()
+  )
+  
   const ref = useRef()
   const [val, setValue] = useState("")
   const [hasFocus, setFocus] = useState(false)
@@ -175,6 +179,8 @@ export const Textarea = ({
     }
   }
   
+  const theId = id || uniqueId()
+  
   return (
     <div>
       <span 
@@ -188,7 +194,7 @@ export const Textarea = ({
         { label && label.length ?
             <Label 
               text={label}
-              htmlFor={id}
+              htmlFor={theId}
               className={`${labelStyles}`}
               disabled={disabled}
               required={required}
@@ -202,7 +208,7 @@ export const Textarea = ({
           name={name}
           autoComplete={autoComplete}
           value={val}
-          id={id}
+          id={theId}
           ref={ref}
           placeholder={placeholder}
           disabled={disabled}

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
@@ -29,9 +29,16 @@ describe("Textarea", () => {
 	})
 	
 	test("renders a Textarea with an id as passed", async () => {
-		render(<Textarea id="my-textinput" />)
+		render(<Textarea id="my-textarea" />)
 		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('id', "my-textinput")
+		expect(screen.getByRole("textbox")).toHaveAttribute('id', "my-textarea")
+	})
+	
+	test("renders a Textarea with an auto-generated id if no id is passed", async () => {
+		render(<Textarea /> )
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("id")
+		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textarea")
 	})
 	
 	test("renders an invalid textarea as passed", async () => {

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
@@ -41,6 +41,20 @@ describe("Textarea", () => {
 		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textarea")
 	})
 	
+	test("renders a Textarea with a label associated by an id as passed", async () => {
+		render(< Textarea label="My Textarea" id="ta-1"/>)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByRole("textbox")).toHaveAttribute("id")
+		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ta-1")
+		expect(screen.getByLabelText("My Textarea")).toBeInTheDocument()
+	})
+	
+	test("renders a Textarea with a label associated by an auto-generated id if no id was passed ", async () => {
+		render(<Textarea label="This is a Textarea" />)
+		expect(screen.getByRole("textbox")).toBeInTheDocument()
+		expect(screen.getByLabelText("This is a Textarea")).toBeInTheDocument()
+	})
+	
 	test("renders an invalid textarea as passed", async () => {
 		render(<Textarea invalid />)
 		expect(screen.getByRole("textbox")).toBeInTheDocument()


### PR DESCRIPTION
This PR introduces unique ids being generated for all input elements and their associated labels if no id was passed. 

* Checkbox
* CheckboxGroup
* Radio
* RadioGroup
* Select
* Switch
* Textarea
* TextInput