### PR TITLE
[ui] [input type]-Row components return FormRow and input element

### DIFF
--- a/libs/juno-ui-components/src/components/CheckboxRow/CheckboxRow.component.js
+++ b/libs/juno-ui-components/src/components/CheckboxRow/CheckboxRow.component.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import { Checkbox } from "../Checkbox/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-/** A single checkbox, associated label, and structural markup */
+/** DEPRECATED: A single checkbox, associated label, and structural markup. This component is DEPRECATED, use Checkbox instead. */
 const CheckboxRow = ({
   value,
   checked,

--- a/libs/juno-ui-components/src/components/CheckboxRow/CheckboxRow.stories.js
+++ b/libs/juno-ui-components/src/components/CheckboxRow/CheckboxRow.stories.js
@@ -7,7 +7,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "CheckboxRow is deprecated, use Checkbox instead."
+        component: "DEPRECATED: A radio row containing a radio, associated label, and structural markup. This component is DEPRECATED, use Radio instead."
       },
     },
   },

--- a/libs/juno-ui-components/src/components/RadioRow/RadioRow.component.js
+++ b/libs/juno-ui-components/src/components/RadioRow/RadioRow.component.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import { Radio } from "../Radio/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-/** A radio row containing a radio, associated label, and structural markup */
+/** DEPRECATED: A radio row containing a radio, associated label, and structural markup. This component is DEPRECATED, use Radio instead. */
 const RadioRow = ({
   value,
   name,

--- a/libs/juno-ui-components/src/components/RadioRow/RadioRow.stories.js
+++ b/libs/juno-ui-components/src/components/RadioRow/RadioRow.stories.js
@@ -7,7 +7,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "RadioRow is deprecated, use Radio instead."
+        component: "DEPRECATED: A radio row containing a radio, associated label, and structural markup. This component is DEPRECATED, use Radio instead."
       },
     },
   },

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.component.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.component.js
@@ -1,42 +1,11 @@
 import React, { useState, useEffect, useMemo } from "react"
 import PropTypes from "prop-types"
 import { Select } from "../Select/index.js"
-import { Label } from "../Label/index.js"
+import { FormRow } from "../FormRow/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-const selectrow = `
-	jn-flex
-	jn-flex-col
-	jn-mb-2
-`
 
-const helptextstyles = `
-	jn-text-xs
-	jn-text-theme-light
-	jn-mt-1
-`
-
-const selectstyles = `
-	jn-w-full
-`
-
-const floatingcontainerstyles = `
-  jn-relative
-`
-
-const errortextstyles = `
-  jn-text-xs
-  jn-text-theme-error
-  jn-mt-1
-`
-
-const successtextstyles = `
-  jn-text-xs
-  jn-text-theme-success
-  jn-mt-1
-`
-
-/** A select group containing an input of type text, password, email, tel, or url, an associated label, and necessary structural markup. */
+/** DEPRECATED: A select group containing a select, an associated label, and necessary structural markup. This component is DEPRECATED, use Select instead. */
 const SelectRow = ({
   name,
   variant,
@@ -62,76 +31,34 @@ const SelectRow = ({
   loading,
   ...props
 }) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [hasError, setHasError] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
-  
-  useEffect(() => {
-    setIsOpen(open)
-  }, [open])
-  
-  useEffect(() => {
-    setHasError(error)
-  }, [error])
-  
-  useEffect(() => {
-    setIsLoading(loading)
-  }, [loading])
-
-  const invalidated = useMemo(
-    () => invalid || (errortext && errortext.length ? true : false),
-    [invalid, errortext]
-  )
-  const validated = useMemo(
-    () => valid || (successtext && successtext.length ? true : false),
-    [valid, successtext]
-  )
-
-  useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-
-  useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
-
   return (
-    <div
-      className={`juno-select-row ${className}`}
-      {...props}
-    >
-      <div>
-        <Select
-          className={`${selectstyles}`}
-          name={name}
-          id={id}
-          label={label}
-          required={required}
-          placeholder={placeholder}
-          onValueChange={onValueChange || onChange}
-          onOpenChange={onOpenChange}
-          disabled={disabled}
-          invalid={isInvalid}
-          valid={isValid}
-          value={value}
-          defaultValue={defaultValue}
-          open={isOpen}
-          error={hasError}
-          loading={isLoading}
-        >
-          {children}
-        </Select>
-        {errortext && errortext.length ? (
-          <p className={`${errortextstyles}`}>{errortext}</p>
-        ) : null}
-        {successtext && successtext.length ? (
-          <p className={`${successtextstyles}`}>{successtext}</p>
-        ) : null}
-        {helptext ? <p className={`${helptextstyles}`}>{helptext}</p> : ""}
-      </div>
-    </div>
+    <FormRow>
+      <Select
+        name={name}
+        id={id}
+        label={label}
+        required={required}
+        placeholder={placeholder}
+        onValueChange={onValueChange || onChange}
+        onOpenChange={onOpenChange}
+        disabled={disabled}
+        invalid={invalid}
+        valid={valid}
+        value={value}
+        variant={variant}
+        defaultValue={defaultValue}
+        open={open}
+        error={error}
+        loading={loading}
+        errortext={errortext}
+        helptext={helptext}
+        successtext={successtext}
+        className={className}
+        {...props}
+      >
+        {children}
+      </Select>
+    </FormRow>
   )
 }
 

--- a/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
+++ b/libs/juno-ui-components/src/components/SelectRow/SelectRow.stories.js
@@ -10,7 +10,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "SelectRow is deprecated, use Select instead."
+        component: "DEPRECATED: A select group containing a select, an associated label, and necessary structural markup. This component is DEPRECATED, use Select instead."
       },
     },
   },

--- a/libs/juno-ui-components/src/components/SwitchRow/SwitchRow.component.js
+++ b/libs/juno-ui-components/src/components/SwitchRow/SwitchRow.component.js
@@ -1,38 +1,12 @@
 import React, { useState, useEffect, useMemo } from "react"
 import PropTypes from "prop-types"
 import { Switch } from "../Switch/index.js"
-import { Label } from "../Label/index.js"
-import { Icon } from "../Icon/index"
+import { FormRow } from "../FormRow/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-const switchrow = `
-	jn-mb-1
-`
 
-const switchcontainerstyles = `
-	jn-mr-2
-	jn-leading-none
-`
 
-const helptextstyles = `
-	jn-text-xs
-	jn-text-theme-light
-	jn-mt-1
-`
-
-const errortextstyles = `
-  jn-text-xs
-  jn-text-theme-error
-  jn-mt-1
-`
-
-const successtextstyles = `
-  jn-text-xs
-  jn-text-theme-success
-  jn-mt-1
-`
-
-/** A checkbox input group containing a checkbox, associated label, and structural markup */
+/** DEPRECATED: A Switch input row containing a switch, associated label, and structural markup. This component is DEPRECATED, use Switch instead. */
 const SwitchRow = ({
   name,
   label,
@@ -50,61 +24,26 @@ const SwitchRow = ({
   onClick,
   ...props
 }) => {
-  const [isOn, setIsOn] = useState(on)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-
-  useEffect(() => {
-    setIsOn(on)
-  }, [on])
-
-  const invalidated = useMemo(
-    () => invalid || (errortext && errortext.length ? true : false),
-    [invalid, errortext]
-  )
-  const validated = useMemo(
-    () => valid || (successtext && successtext.length ? true : false),
-    [valid, successtext]
-  )
-
-  useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-
-  useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
-
-  const handleChange = (event) => {
-    setIsOn(!isOn)
-    onChange && onChange(event)
-  }
-
   return (
-    <div className={`juno-switch-row ${switchrow} ${className}`} {...props}>
-      <div className={`juno-switch-container ${switchcontainerstyles}`}>
-        <Switch
-          name={name}
-          label={label}
-          onChange={handleChange}
-          onClick={onClick}
-          id={id}
-          on={on}
-          disabled={disabled}
-          invalid={isInvalid}
-          valid={isValid}
-        />
-      </div>
-      <div className={`jn-pt-0.5`}>
-        {errortext && errortext.length ? (
-          <p className={`${errortextstyles}`}>{errortext}</p>
-        ) : null}
-        {successtext && successtext.length ? (
-          <p className={`${successtextstyles}`}>{successtext}</p>
-        ) : null}
-        {helptext ? <p className={`${helptextstyles}`}>{helptext}</p> : null}
-      </div>
-    </div>
+    <FormRow>
+      <Switch
+        name={name}
+        label={label}
+        onChange={onChange}
+        onClick={onClick}
+        id={id}
+        on={on}
+        disabled={disabled}
+        invalid={invalid}
+        required={required}
+        valid={valid}
+        errortext={errortext}
+        helptext={helptext}
+        successtext={successtext}
+        className={className}
+        {...props}
+      />
+    </FormRow>
   )
 }
 

--- a/libs/juno-ui-components/src/components/SwitchRow/SwitchRow.stories.js
+++ b/libs/juno-ui-components/src/components/SwitchRow/SwitchRow.stories.js
@@ -7,7 +7,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "SwitchRow is deprecated, use Switch instead."
+        component: "DEPRECATED: A Switch input row containing a switch, associated label, and structural markup. This component is DEPRECATED, use Switch instead. "
       },
     },
   },

--- a/libs/juno-ui-components/src/components/TextInputRow/TextInputRow.component.js
+++ b/libs/juno-ui-components/src/components/TextInputRow/TextInputRow.component.js
@@ -1,34 +1,10 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 import { TextInput } from "../TextInput/index.js"
-import { Label } from "../Label/index.js"
-import { Icon } from "../Icon/index"
+import { FormRow } from "../FormRow/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-
-const inputcontainerstyles = `
-  jn-relative
-`
-
-const helptextstyles = `
-	jn-text-xs
-	jn-text-theme-light
-	jn-mt-1
-`
-
-const errortextstyles = `
-  jn-text-xs
-  jn-text-theme-error
-  jn-mt-1
-`
-
-const successtextstyles = `
-  jn-text-xs
-  jn-text-theme-success
-  jn-mt-1
-`
-
-/** A text input group containing an input of type text, password, email, tel, or url, an associated label, and necessary structural markup. */
+/** DEPRECATED: A text input row containing an input of type text, password, email, tel, or url, an associated label, and necessary structural markup. This component is DEPRECATED, use TextInput instead. */
 const TextInputRow = ({
   type,
   value,
@@ -50,80 +26,30 @@ const TextInputRow = ({
   onBlur,
   ...props
 }) => {
-  const [val, setValue] = useState("")
-  const [focus, setFocus] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-
-  React.useEffect(() => {
-    setValue(value)
-  }, [value])
-
-  const invalidated = useMemo(
-    () => invalid || (errortext && errortext.length ? true : false),
-    [invalid, errortext]
-  )
-  const validated = useMemo(
-    () => valid || (successtext && successtext.length ? true : false),
-    [valid, successtext]
-  )
-
-  useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-
-  useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
-
-  useEffect(() => {
-    setFocus(autoFocus)
-  }, [autoFocus])
-
-  const handleChange = (event) => {
-    setValue(event.target.value)
-    onChange && onChange(event)
-  }
-
-  const handleFocus = (event) => {
-    setFocus(true)
-    if (onFocus) onFocus(event)
-  }
-  const handleBlur = (event) => {
-    setFocus(false)
-    if (onBlur) onBlur(event)
-  }
-
-
   return (
-    <div
-      className={`juno-textinput-row ${className}`}
-      {...props}
-    >
+    <FormRow>
       <TextInput
         type={type}
-        value={val}
+        value={value}
         name={name}
         id={id}
         label={label}
         required={required}
         placeholder={placeholder}
         disabled={disabled}
-        invalid={isInvalid}
-        valid={isValid}
+        invalid={invalid}
+        valid={valid}
         autoFocus={autoFocus}
-        onChange={handleChange}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
+        onChange={onChange}
+        errortext={errortext}
+        helptext={helptext}
+        successtext={successtext}
+        className={className}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        {...props}
       />
-      {errortext && errortext.length ? (
-        <p className={`${errortextstyles}`}>{errortext}</p>
-      ) : null}
-      {successtext && successtext.length ? (
-        <p className={`${successtextstyles}`}>{successtext}</p>
-      ) : null}
-      {helptext ? <p className={`${helptextstyles}`}>{helptext}</p> : null}
-    </div>
+    </FormRow>
   )
 }
 

--- a/libs/juno-ui-components/src/components/TextInputRow/TextInputRow.stories.js
+++ b/libs/juno-ui-components/src/components/TextInputRow/TextInputRow.stories.js
@@ -7,7 +7,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "TextInputRow is deprecated, use TextInput instead."
+        component: "DEPRECATED: A text input row containing an input of type text, password, email, tel, or url, an associated label, and necessary structural markup. This component is DEPRECATED, use TextInput instead."
       },
     },
   },

--- a/libs/juno-ui-components/src/components/TextareaRow/TextareaRow.component.js
+++ b/libs/juno-ui-components/src/components/TextareaRow/TextareaRow.component.js
@@ -1,80 +1,10 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 import { Textarea } from "../Textarea/index.js"
-import { Label } from "../Label/index.js"
-import { Icon } from "../Icon/index"
+import { FormRow } from "../FormRow/index.js"
 import { withDeprecationWarning } from '../withDeprecationWarning/index.js'
 
-/* Stacked: Label is above the text input element */
-const stackedcontainerstyles = `
-	jn-flex
-	jn-flex-col
-	jn-mb-2
-`
-
-/* Floating: Label is inside the text input element. This is the overall container.  */
-const floatingcontainerstyles = `
-	jn-relative
-	jn-mb-2
-`
-
-/* Styles for FLOATING label container element depending on whether it is currently minimized or not. */
-/* All transforms are applied to the container element! */
-const floatinglabelcontainerstyles = (minimizedLabel) => {
-  return `
-    jn-absolute
-    jn-top-0
-    jn-left-0
-    jn-p-2.5
-    jn-pl-3
-    jn-pt-[0.4325rem]
-    jn-pointer-events-none
-    jn-transform 
-    jn-origin-top-left 
-    jn-transition-all 
-    jn-duration-100 
-    jn-ease-in-out
-    jn-z-10
-
-    ${
-      minimizedLabel &&
-      `
-      jn-scale-75
-      jn-opacity-75
-      -jn-translate-y-2
-      jn-translate-x-1
-      `
-    }
-  `
-}
-
-const inputcontainerstyles = `
-  jn-relative
-`
-
-const helptextstyles = `
-	jn-text-xs
-	jn-text-theme-light
-	jn-mt-1
-`
-
-const errortextstyles = `
-  jn-text-xs
-  jn-text-theme-error
-  jn-mt-1
-`
-
-const successtextstyles = `
-  jn-text-xs
-  jn-text-theme-success
-  jn-mt-1
-`
-
-const stackedinputstyles = `
-	jn-w-full
-`
-
-/** A textarea group containing a textarea, associated label, optional helptext, and structural markup */
+/** DEPRECATED: A textarea row containing a textarea, associated label, optional helptext, and structural markup. This component is DEPRECATED, use Textarea instead. */
 
 const TextareaRow = ({
   value,
@@ -93,74 +23,26 @@ const TextareaRow = ({
   onChange,
   ...props
 }) => {
-  const [val, setValue] = useState("")
-  const [focus, setFocus] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-
-  React.useEffect(() => {
-    setValue(value)
-  }, [value])
-
-  const invalidated = useMemo(
-    () => invalid || (errortext && errortext.length ? true : false),
-    [invalid, errortext]
-  )
-  const validated = useMemo(
-    () => valid || (successtext && successtext.length ? true : false),
-    [valid, successtext]
-  )
-
-  useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-
-  useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
-
-  const handleChange = (event) => {
-    setValue(event.target.value)
-    onChange && onChange(event)
-  }
-  
-  const textarearightpadding = () => {
-    if ( isValid || isInvalid ) {
-      return iconpadding
-    } else {
-      return ""
-    }
-  }
-
   return (
-    <div
-      className={`juno-textarea-row  ${className}`}
-      {...props}
-    >
-      <div className={`juno-input-container ${inputcontainerstyles}`}>
-        <Textarea
-          value={val}
-          name={name}
-          id={id}
-          label={label}
-          required={required}
-          placeholder={placeholder}
-          disabled={disabled}
-          invalid={isInvalid}
-          valid={isValid}
-          onChange={handleChange}
-          onFocus={() => setFocus(true)}
-          onBlur={() => setFocus(false)}
-        />
-        {errortext && errortext.length ? (
-          <p className={`${errortextstyles}`}>{errortext}</p>
-        ) : null}
-        {successtext && successtext.length ? (
-          <p className={`${successtextstyles}`}>{successtext}</p>
-        ) : null}
-        {helptext ? <p className={`${helptextstyles}`}>{helptext}</p> : null}
-      </div>
-    </div>
+    <FormRow>
+      <Textarea
+        value={value}
+        name={name}
+        id={id}
+        label={label}
+        required={required}
+        placeholder={placeholder}
+        disabled={disabled}
+        invalid={invalid}
+        valid={valid}
+        onChange={onChange}
+        errortext={errortext}
+        helptext={helptext}
+        successtext={successtext}
+        className={className}
+        {...props}
+      />
+    </FormRow>
   )
 }
 

--- a/libs/juno-ui-components/src/components/TextareaRow/TextareaRow.stories.js
+++ b/libs/juno-ui-components/src/components/TextareaRow/TextareaRow.stories.js
@@ -7,7 +7,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: "TextareaRow is deprecated, use Textarea instead."
+        component: "DEPRECATED: A textarea row containing a textarea, associated label, optional helptext, and structural markup. This component is DEPRECATED, use Textarea instead."
       },
     },
   },


### PR DESCRIPTION
RadioRow, CheckboxRow, SelectRow, SwitchRow, TextareaRow, and TextInputRow now only return a FormRow wrapping the respective input element. All props are being passed to the input element now.