### PR TITLE
[ui] don’t cut off Select value when rendering a label

### DIFF
--- a/libs/juno-ui-components/src/components/Select/Select.component.js
+++ b/libs/juno-ui-components/src/components/Select/Select.component.js
@@ -15,7 +15,7 @@ const wrapperStyles = `
 const labelStyles = `
   jn-pointer-events-none
   jn-top-2
-  jn-left-[0.9375rem]
+  jn-left-4
 `
 
 const triggerStyles = `
@@ -35,7 +35,8 @@ const triggerStyles = `
 `
 
 const triggerLabelStyles = `
-  jn-pt-3.5 
+  jn-text-left
+  jn-pt-[0.4rem]
 `
 
 const triggerErrorStyles = `

--- a/libs/juno-ui-components/src/components/Select/select.scss
+++ b/libs/juno-ui-components/src/components/Select/select.scss
@@ -67,10 +67,11 @@
 .juno-select-trigger {
   
   > span:first-child {
-    height: 1.5rem;
+    height: 1.75rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-align: left;
   }
   
 }


### PR DESCRIPTION
* prevent Select trigger button label (representing the selected value) from being cutt off when rendering a label