### PR TITLE
[ui] Select: allow `onValueChange` and `onChange` handlers

### DIFF
--- a/libs/juno-ui-components/src/components/Select/Select.component.js
+++ b/libs/juno-ui-components/src/components/Select/Select.component.js
@@ -106,6 +106,7 @@ export const Select = React.forwardRef(
     labelClassName,
     loading,
     name,
+    onChange,
     onOpenChange,
     onValueChange,
     open,
@@ -176,6 +177,11 @@ export const Select = React.forwardRef(
       onOpenChange && onOpenChange(event)
     }
     
+    const handleValueChange = (event) => {
+      onValueChange && onValueChange(event) 
+      onChange && onChange(event)
+    }
+    
     const theVariant = variant || "default"
     
     const TriggerIcons = () => {
@@ -235,7 +241,7 @@ export const Select = React.forwardRef(
               disabled={disabled || hasError || isLoading} 
               name={name}
               onOpenChange={handleOpenChange}
-              onValueChange={onValueChange}
+              onValueChange={handleValueChange}
               value={value}
               open={isOpen}
               defaultValue={defaultValue}
@@ -337,6 +343,8 @@ Select.propTypes = {
   loading: PropTypes.bool,
   /** The name of the Select. When a form is submitted, this will be posted as name:value. */
   name: PropTypes.string,
+  /** Handler to be executed when the selected value changes. Alternative API to `onValueChange`. Both will work. */
+  onChange: PropTypes.func,
   /** Handler to be executed when the open state a controlled Select changes */
   onOpenChange: PropTypes.func,
   /** Handler to be executed when the selected value changes. */
@@ -384,6 +392,7 @@ Select.defaultProps = {
   labelClassName: "",
   loading: false,
   name: "",
+  onChange: undefined,
   onOpenChange: undefined,
   onValueChange: undefined,
   open: undefined,

--- a/libs/juno-ui-components/src/components/Select/Select.test.js
+++ b/libs/juno-ui-components/src/components/Select/Select.test.js
@@ -7,6 +7,7 @@ import { SelectOption } from "../SelectOption/index"
 
 const mockOnValueChange = jest.fn()
 const mockOnOpenChange = jest.fn()
+const mockOnChange = jest.fn()
 
 const SelectParent = ({
     value, 
@@ -303,6 +304,22 @@ describe("Select", () => {
     expect(select).toHaveTextContent("Option 3")
     expect(mockOnValueChange).toHaveBeenCalled()
   })
+  
+  test("executes an onChange handler when selected value changes", async () => {
+    render(
+      <SelectParent onChange={mockOnChange} >
+        <SelectOption value="val-1">Option 1</SelectOption>
+        <SelectOption value="val-2">Option 2</SelectOption>
+      </SelectParent>
+    )
+    const select = screen.getByRole("combobox")
+    expect(select).toBeInTheDocument()
+    await userEvent.click(select)
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("option", { name: "Option 2" }))
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+  
   
   test("renders a className to the Select trigger button as passed", async () => {
     render(


### PR DESCRIPTION
* add `onChange` handler to Select for consistency with the rest of Juno. Both `onChange` and `onValueChange` will run when the select changes.