### PR TITLE
[ui] AppShell: properly handle full-width/responsive behaviour

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
+++ b/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
@@ -98,7 +98,7 @@ AppShell.propTypes = {
   /** Optional: Defaults to false. Set embedded to true if app is to be rendered embedded in another app/page. 
    * In this case only the content area and children are rendered, no header/footer or remaining layout components */
   embedded: PropTypes.bool,
-  /** Whether the main page / view content can spread over the full available width of the viewport or not. Default is `false` (resulting in a width-constrained, centered content column on very wide screens) UNLESS the AppShell is rendered with embedded as true, then the main content will be full-width by default. In embedded mode, `fullWidthContnet` can still be passed as `false` explicitly. */
+  /** Whether the main page / view content can spread over the full available width of the viewport or not. Default is `false` (resulting in a width-constrained, centred content column on very wide screens) UNLESS the AppShell is rendered with embedded as true, then the main content will be full-width by default. In embedded mode, `fullWidthContent` can still be passed as `false` explicitly. */
   fullWidthContent: PropTypes.bool,
   /** Add a custom class name */
   className: PropTypes.string,

--- a/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
+++ b/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
@@ -25,6 +25,14 @@ export const AppShell = ({
   topNavigation, 
   ...props 
 }) => {
+  
+  // Determine whether to pass set fullWidth to true in embedded mode or not:
+  // In non-embedded mode, fullWidthContent should default to false as specified in defaultProps, unless explitly set to true.
+  // In embedded mode though, fullWidthContent should default to true, but will accept false if explicitly passed.
+  //const embeddedFullWidth = embedded ? !fullWidthContent || true : fullWidthContent === true
+  
+  
+  
   return (
     <AppBody className={className} {...props}>
     
@@ -36,7 +44,7 @@ export const AppShell = ({
           
       { embedded ?
         <MainContainer>
-          <MainContainerInner fullWidth={fullWidthContent} hasSideNav={ sideNavigation ? true : false }>
+          <MainContainerInner fullWidth={fullWidthContent === false ? false : true} hasSideNav={ sideNavigation ? true : false }>
             { sideNavigation && sideNavigation }
             <ContentContainer>
               {children}
@@ -55,7 +63,7 @@ export const AppShell = ({
           { topNavigation && topNavigation }
           {/* Wrap everything except page header and footer and navigations in a main container. Add top margin to MainContainerInner as we are not in embedded mode here. */}
           <MainContainer>
-            <MainContainerInner fullWidth={fullWidthContent} hasSideNav={ sideNavigation ? true : false } className="jn-mt-[3.875rem]">
+            <MainContainerInner fullWidth={fullWidthContent === true ? true : false } hasSideNav={ sideNavigation ? true : false } className="jn-mt-[3.875rem]">
               { sideNavigation && sideNavigation }
               {/* Content Container. This is the place to add the app's main content. Render left margin only if no SideNavigation is present. */}
               <ContentContainer className={ sideNavigation ? "" : "jn-ml-8"}>
@@ -93,9 +101,9 @@ AppShell.propTypes = {
   /** Optional: Defaults to false. Set embedded to true if app is to be rendered embedded in another app/page. 
    * In this case only the content area and children are rendered, no header/footer or remaining layout components */
   embedded: PropTypes.bool,
-  /** Whether the main page / view content can spread over the full available width of the viewport or not. Default is `false`, resulting in a width-constrained, centered content column on very wide screens. */
+  /** Whether the main page / view content can spread over the full available width of the viewport or not. Default is `false` (resulting in a width-constrained, centered content column on very wide screens) UNLESS the AppShell is rendered with embedded as true, then the main content will be full-width by default. In embedded mode, `fullWidthContnet` can still be passed as `false` explicitly. */
   fullWidthContent: PropTypes.bool,
-  /** Add custom class name */
+  /** Add a custom class name */
   className: PropTypes.string,
 }
 
@@ -106,6 +114,6 @@ AppShell.defaultProps = {
   sideNavigation: undefined,
   contentHeading: "",
   embedded: false,
-  fullWidthContent: false,
+  fullWidthContent: undefined,
   className: "",
 }

--- a/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
+++ b/libs/juno-ui-components/src/components/AppShell/AppShell.component.js
@@ -27,11 +27,8 @@ export const AppShell = ({
 }) => {
   
   // Determine whether to pass set fullWidth to true in embedded mode or not:
-  // In non-embedded mode, fullWidthContent should default to false as specified in defaultProps, unless explitly set to true.
-  // In embedded mode though, fullWidthContent should default to true, but will accept false if explicitly passed.
-  //const embeddedFullWidth = embedded ? !fullWidthContent || true : fullWidthContent === true
-  
-  
+  // In non-embedded mode, fullWidthContent should default to false, unless explicitly set to true.
+  // In embedded mode though, fullWidthContent should default to true, unless explicitly passed as false.
   
   return (
     <AppBody className={className} {...props}>

--- a/libs/juno-ui-components/src/components/AppShell/AppShell.test.js
+++ b/libs/juno-ui-components/src/components/AppShell/AppShell.test.js
@@ -98,6 +98,28 @@ describe("AppShell", () => {
     expect(screen.getByTestId("app-shell")).toBeInTheDocument()
     expect(screen.getByRole("button")).toBeInTheDocument()
   })
+  
+  
+  // The following test whether the MainContainerInner element rendered by AppShell does the right thing depending of props passed to AppShell:
+  test("does not render a fullwidth main container in non-embedded mode by default", async () => {
+    render(<AppShell><button></button></AppShell>)
+    expect(document.querySelector(".juno-main-inner")).not.toHaveClass("juno-main-inner-fullwidth")
+  })
+  
+  test("renders a fullwidth main container in non-embedded mode if passed explicitly", async () => {
+    render(<AppShell fullWidthContent={true}><button></button></AppShell>)
+    expect(document.querySelector(".juno-main-inner")).toHaveClass("juno-main-inner-fullwidth")
+  })
+  
+  test("renders a fullwidth main inner container in embedded mode by default", async () => {
+    render(<AppShell embedded><button></button></AppShell>)
+    expect(document.querySelector(".juno-main-inner")).toHaveClass("juno-main-inner-fullwidth")
+  })
+  
+  test("renders a non-fullwidth, size-restricted main inner container in embedded mode if passed explicitly", async () => {
+    render(<AppShell embedded fullWidthContent={false}><button></button></AppShell>)
+    expect(document.querySelector(".juno-main-inner")).not.toHaveClass("juno-main-inner-fullwidth")
+  })
 
   test("renders a custom className", async () => {
     render(<AppShell data-testid="app-shell" className="my-custom-classname" />)

--- a/libs/juno-ui-components/src/components/MainContainerInner/MainContainerInner.component.js
+++ b/libs/juno-ui-components/src/components/MainContainerInner/MainContainerInner.component.js
@@ -32,7 +32,7 @@ export const MainContainerInner = ({
          ${ !fullWidth ? 
             ( hasSideNav ? constrainWithSideNavStyles : constrainStyles )
            :
-            ""
+            "juno-main-inner-fullwidth"
          }
          ${className}`
       }

--- a/libs/juno-ui-components/src/components/MainContainerInner/MainContainerInner.test.js
+++ b/libs/juno-ui-components/src/components/MainContainerInner/MainContainerInner.test.js
@@ -20,6 +20,30 @@ describe("MainContainerInner", () => {
     expect(screen.getByRole("button")).toBeInTheDocument()
   })
   
+  test("renders the expected width-constraining responsive classes if not fullwidth and there is no sidenav", async () => {
+    render(<MainContainerInner data-testid="main-inner" fullWidth={false} hasSideNav={false} />)
+    expect(screen.getByTestId("main-inner")).toBeInTheDocument()
+    expect(screen.getByTestId("main-inner")).toHaveClass("2xl:jn-container")
+    expect(screen.getByTestId("main-inner")).toHaveClass("2xl:jn-mx-auto")
+  })
+  
+  test("renders the expected width-constraining responsive classes if not fullwidth and there is a sidenav", async () => {
+    render(<MainContainerInner data-testid="main-inner" fullWidth={false} hasSideNav={true} />)
+    expect(screen.getByTestId("main-inner")).toBeInTheDocument()
+    expect(screen.getByTestId("main-inner")).toHaveClass("3xl:jn-container")
+    expect(screen.getByTestId("main-inner")).toHaveClass("3xl:jn-mx-auto")
+  })
+  
+  test("does not render any width-constraining responsive classes if in fullwidth mode", async () => {
+    render(<MainContainerInner data-testid="main-inner" fullWidth={true} />)
+    expect(screen.getByTestId("main-inner")).toBeInTheDocument()
+    expect(screen.getByTestId("main-inner")).toHaveClass("juno-main-inner-fullwidth")
+    expect(screen.getByTestId("main-inner")).not.toHaveClass("2xl:jn-container")
+    expect(screen.getByTestId("main-inner")).not.toHaveClass("2xl:jn-mx-auto")
+    expect(screen.getByTestId("main-inner")).not.toHaveClass("3xl:jn-container")
+    expect(screen.getByTestId("main-inner")).not.toHaveClass("3xl:jn-mx-auto")
+  })
+  
   test("renders a custom className", async () => {
     render(<MainContainerInner data-testid="main-inner" className="my-custom-classname"/>)
     expect(screen.getByTestId("main-inner")).toBeInTheDocument()


### PR DESCRIPTION
* In embedded mode, we render full-width content by default
* In non-embedded/default mode, we render width-restricted content
* in both modes, users can pass `fullWidthContent` explictlty for desired non-default behaviour