### PR TITLE
[Storybook] component wrapper

### DIFF
--- a/libs/juno-ui-components/src/docs/ColorPalette/ColorPalette.jsx
+++ b/libs/juno-ui-components/src/docs/ColorPalette/ColorPalette.jsx
@@ -1,12 +1,9 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import tailwindColors from "./TailwindColors"
 import { ColorCard } from "./ColorCard"
 import { TextColorCard } from "./TextColorCard"
 
-import { StyleProvider } from "../../components/StyleProvider"
 import { ContentArea } from "../../components/ContentArea/index"
-import { getCurrentThemeMode } from "../../../.storybook/juno-addon/themes"
-import { useChannel, addons } from "@storybook/preview-api"
 
 // Shows the colors from tailwind classes for a given theme (props.theme)
 export function ColorPalette(props) {
@@ -19,60 +16,33 @@ export function ColorPalette(props) {
     )
   }
 
-  const [parentTheme, setParentTheme] = useState(
-    "theme-" + getCurrentThemeMode()
-  )
-
-  useEffect(() => {
-    const updateThemeClass = (mode) => {
-      setParentTheme("theme-" + mode)
-    }
-    const channel = addons.getChannel()
-    if (channel) {
-      channel.on("JUNO_THEME_CHANGE", updateThemeClass)
-    }
-    return () => {
-      if (channel) channel.off("JUNO_THEME_CHANGE", updateThemeClass)
-    }
-  }, [])
-
   const theme = props.theme
   const gridStyle = `jn-grid jn-gap-4 xl:jn-grid-cols-4 md:jn-grid-cols-3 jn-grid-cols-2 jn-mb-6`
   const h2Style = "jn-text-xl jn-my-2 jn-font-semibold"
 
   return (
-    <div>
-      <StyleProvider
-        key="decorator"
-        stylesWrapper="shadowRoot"
-        theme={parentTheme}
-      >
-        <ContentArea className={`jn-p-4 jn-rounded-xl ${theme}`}>
-          <h2 className={h2Style}>Theme colors</h2>
-          <div className={gridStyle}>
-            {Object.entries(tailwindColors.getThemeColors).map((color) => (
-              <ColorCard
-                key={color[0]}
-                prefix="theme-"
-                colorName={color[0]}
-                colorClass={color[1]}
-              />
-            ))}
-          </div>
-          <h2 className={h2Style}>Font colors</h2>
-          <div className={gridStyle}>
-            {Object.entries(tailwindColors.getThemeTextColors).map(
-              (textColor) => (
-                <TextColorCard
-                  key={textColor[0]}
-                  colorName={textColor[0]}
-                  colorClass={textColor[1]}
-                />
-              )
-            )}
-          </div>
-        </ContentArea>
-      </StyleProvider>
-    </div>
+    <ContentArea className={`jn-p-4 jn-rounded-xl ${theme}`}>
+      <h2 className={h2Style}>Theme colors</h2>
+      <div className={gridStyle}>
+        {Object.entries(tailwindColors.getThemeColors).map((color) => (
+          <ColorCard
+            key={color[0]}
+            prefix="theme-"
+            colorName={color[0]}
+            colorClass={color[1]}
+          />
+        ))}
+      </div>
+      <h2 className={h2Style}>Font colors</h2>
+      <div className={gridStyle}>
+        {Object.entries(tailwindColors.getThemeTextColors).map((textColor) => (
+          <TextColorCard
+            key={textColor[0]}
+            colorName={textColor[0]}
+            colorClass={textColor[1]}
+          />
+        ))}
+      </div>
+    </ContentArea>
   )
 }

--- a/libs/juno-ui-components/src/docs/ColorPalette/JunoColorPalette.jsx
+++ b/libs/juno-ui-components/src/docs/ColorPalette/JunoColorPalette.jsx
@@ -1,52 +1,24 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import tailwindColors from "./TailwindColors"
 import { ColorCard } from "./ColorCard"
 
-import { StyleProvider } from "../../components/StyleProvider"
 import { ContentArea } from "../../components/ContentArea/index"
-import { getCurrentThemeMode } from "../../../.storybook/juno-addon/themes"
-import { useChannel, addons } from "@storybook/preview-api"
 
 // Shows the colors from tailwind classes for a given theme (props.theme)
 export function JunoColorPalette(props) {
-  const [parentTheme, setParentTheme] = useState(
-    "theme-" + getCurrentThemeMode()
-  )
-
-  useEffect(() => {
-    const updateThemeClass = (mode) => {
-      setParentTheme("theme-" + mode)
-    }
-    const channel = addons.getChannel()
-    if (channel) {
-      channel.on("JUNO_THEME_CHANGE", updateThemeClass)
-    }
-    return () => {
-      if (channel) channel.off("JUNO_THEME_CHANGE", updateThemeClass)
-    }
-  }, [])
-
   const gridStyle = `jn-grid jn-gap-4 xl:jn-grid-cols-4 md:jn-grid-cols-3 jn-grid-cols-2 jn-mb-6`
 
   return (
-    <div>
-      <StyleProvider
-        key="decorator"
-        stylesWrapper="shadowRoot"
-        theme={parentTheme}
-      >
-        <ContentArea className={`jn-p-4`}>
-          <div className={gridStyle}>
-            {Object.entries(tailwindColors.getJunoColors).map((color) => (
-              <ColorCard
-                key={color[0]}
-                colorName={color[0]}
-                colorClass={color[1]}
-              />
-            ))}
-          </div>
-        </ContentArea>
-      </StyleProvider>
-    </div>
+    <ContentArea className={`jn-p-4`}>
+      <div className={gridStyle}>
+        {Object.entries(tailwindColors.getJunoColors).map((color) => (
+          <ColorCard
+            key={color[0]}
+            colorName={color[0]}
+            colorClass={color[1]}
+          />
+        ))}
+      </div>
+    </ContentArea>
   )
 }

--- a/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
@@ -2,27 +2,27 @@
 It is needed for the ColorPalette and JunoColorPalette to show the documented colors.
 We need to do this because Tailwind classes can't be concatenated at runtime via String interpolation. It only works if you use the full class name.*/
 exports.getThemeColors = {
-  "accent": "jn-bg-theme-accent",
-  "danger": "jn-bg-theme-danger",
-  "error": "jn-bg-theme-error",
-  "info": "jn-bg-theme-info",
-  "success": "jn-bg-theme-success",
-  "warning": "jn-bg-theme-warning",
-  "focus": "jn-bg-theme-focus",
+  accent: "jn-bg-theme-accent",
+  danger: "jn-bg-theme-danger",
+  error: "jn-bg-theme-error",
+  info: "jn-bg-theme-info",
+  success: "jn-bg-theme-success",
+  warning: "jn-bg-theme-warning",
+  focus: "jn-bg-theme-focus",
   "background-lvl-0": "jn-bg-theme-background-lvl-0",
   "background-lvl-1": "jn-bg-theme-background-lvl-1",
   "background-lvl-2": "jn-bg-theme-background-lvl-2",
   "background-lvl-3": "jn-bg-theme-background-lvl-3",
   "background-lvl-4": "jn-bg-theme-background-lvl-4",
-  "background-lvl-5": "jn-bg-theme-background-lvl-5"
+  "background-lvl-5": "jn-bg-theme-background-lvl-5",
 }
 exports.getThemeTextColors = {
-  "highest": "jn-text-theme-highest",
-  "high": "jn-text-theme-high",
-  "default": "jn-text-theme-default",
-  "light": "jn-text-theme-light",
-  "disabled": "jn-text-theme-disabled",
-  "link": "jn-text-theme-link"
+  highest: "jn-text-theme-highest",
+  high: "jn-text-theme-high",
+  default: "jn-text-theme-default",
+  light: "jn-text-theme-light",
+  disabled: "jn-text-theme-disabled",
+  link: "jn-text-theme-link",
 }
 exports.getJunoColors = {
   "juno-grey-blue": "jn-bg-juno-grey-blue",
@@ -71,6 +71,15 @@ exports.getJunoColors = {
   "juno-grey-light-9": "jn-bg-juno-grey-light-9",
   "juno-grey-light-10": "jn-bg-juno-grey-light-10",
   "juno-grey-light-11": "jn-bg-juno-grey-light-11",
+  "juno-red": "jn-bg-juno-red",
+  "juno-red-1": "jn-bg-juno-red-1",
+  "juno-red-2": "jn-bg-juno-red-2",
+  "juno-red-3": "jn-bg-juno-red-3",
+  "juno-red-4": "jn-bg-juno-red-4",
+  "juno-red-5": "jn-bg-juno-red-5",
+  "juno-red-6": "jn-bg-juno-red-6",
+  "juno-red-7": "jn-bg-juno-red-7",
+  "juno-red-8": "jn-bg-juno-red-8",
   "sap-grey": "jn-bg-sap-grey",
   "sap-grey-1": "jn-bg-sap-grey-1",
   "sap-grey-2": "jn-bg-sap-grey-2",
@@ -102,6 +111,6 @@ exports.getJunoColors = {
   "sap-green-4": "jn-bg-sap-green-4",
   "sap-green-5": "jn-bg-sap-green-5",
   "sap-green-6": "jn-bg-sap-green-6",
-  "white": "jn-bg-white",
-  "black": "jn-bg-black"
+  white: "jn-bg-white",
+  black: "jn-bg-black",
 }

--- a/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
@@ -2,27 +2,27 @@
 It is needed for the ColorPalette and JunoColorPalette to show the documented colors.
 We need to do this because Tailwind classes can't be concatenated at runtime via String interpolation. It only works if you use the full class name.*/
 exports.getThemeColors = {
-  accent: "jn-bg-theme-accent",
-  danger: "jn-bg-theme-danger",
-  error: "jn-bg-theme-error",
-  info: "jn-bg-theme-info",
-  success: "jn-bg-theme-success",
-  warning: "jn-bg-theme-warning",
-  focus: "jn-bg-theme-focus",
+  "accent": "jn-bg-theme-accent",
+  "danger": "jn-bg-theme-danger",
+  "error": "jn-bg-theme-error",
+  "info": "jn-bg-theme-info",
+  "success": "jn-bg-theme-success",
+  "warning": "jn-bg-theme-warning",
+  "focus": "jn-bg-theme-focus",
   "background-lvl-0": "jn-bg-theme-background-lvl-0",
   "background-lvl-1": "jn-bg-theme-background-lvl-1",
   "background-lvl-2": "jn-bg-theme-background-lvl-2",
   "background-lvl-3": "jn-bg-theme-background-lvl-3",
   "background-lvl-4": "jn-bg-theme-background-lvl-4",
-  "background-lvl-5": "jn-bg-theme-background-lvl-5",
+  "background-lvl-5": "jn-bg-theme-background-lvl-5"
 }
 exports.getThemeTextColors = {
-  highest: "jn-text-theme-highest",
-  high: "jn-text-theme-high",
-  default: "jn-text-theme-default",
-  light: "jn-text-theme-light",
-  disabled: "jn-text-theme-disabled",
-  link: "jn-text-theme-link",
+  "highest": "jn-text-theme-highest",
+  "high": "jn-text-theme-high",
+  "default": "jn-text-theme-default",
+  "light": "jn-text-theme-light",
+  "disabled": "jn-text-theme-disabled",
+  "link": "jn-text-theme-link"
 }
 exports.getJunoColors = {
   "juno-grey-blue": "jn-bg-juno-grey-blue",
@@ -111,6 +111,6 @@ exports.getJunoColors = {
   "sap-green-4": "jn-bg-sap-green-4",
   "sap-green-5": "jn-bg-sap-green-5",
   "sap-green-6": "jn-bg-sap-green-6",
-  white: "jn-bg-white",
-  black: "jn-bg-black",
+  "white": "jn-bg-white",
+  "black": "jn-bg-black"
 }

--- a/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
@@ -64,6 +64,7 @@ const getJunoColors = () => {
   const allowList = [
     "juno-grey-blue",
     "juno-blue",
+    "juno-red",
     "juno-turquoise",
     "juno-grey-light",
     "sap-grey",

--- a/libs/juno-ui-components/src/docs/JunoComponentParent/JunoComponentParent.jsx
+++ b/libs/juno-ui-components/src/docs/JunoComponentParent/JunoComponentParent.jsx
@@ -5,6 +5,7 @@ import { getCurrentThemeMode } from "../../../.storybook/juno-addon/themes"
 import { addons } from "@storybook/preview-api"
 
 // allows to implement themed components in the storybook
+// component adjusts to the selected theme and enables tailwind classes.
 export function JunoComponentParent(props) {
   // returns nothing if there is no child
   if (!props.children) {

--- a/libs/juno-ui-components/src/docs/JunoComponentParent/JunoComponentParent.jsx
+++ b/libs/juno-ui-components/src/docs/JunoComponentParent/JunoComponentParent.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react"
+
+import { StyleProvider } from "../../components/StyleProvider/StyleProvider.component"
+import { getCurrentThemeMode } from "../../../.storybook/juno-addon/themes"
+import { addons } from "@storybook/preview-api"
+
+// allows to implement themed components in the storybook
+export function JunoComponentParent(props) {
+  // returns nothing if there is no child
+  if (!props.children) {
+    return
+  }
+
+  const [parentTheme, setParentTheme] = useState(
+    "theme-" + getCurrentThemeMode()
+  )
+
+  useEffect(() => {
+    const updateThemeClass = (mode) => {
+      setParentTheme("theme-" + mode)
+    }
+    const channel = addons.getChannel()
+    if (channel) {
+      channel.on("JUNO_THEME_CHANGE", updateThemeClass)
+    }
+    return () => {
+      if (channel) channel.off("JUNO_THEME_CHANGE", updateThemeClass)
+    }
+  }, [])
+
+  return (
+    <div>
+      <StyleProvider
+        key="decorator"
+        stylesWrapper="shadowRoot"
+        theme={parentTheme}
+      >
+        {props.children}
+      </StyleProvider>
+    </div>
+  )
+}

--- a/libs/juno-ui-components/src/docs/JunoComponentWrapper/JunoComponentWrapper.jsx
+++ b/libs/juno-ui-components/src/docs/JunoComponentWrapper/JunoComponentWrapper.jsx
@@ -6,7 +6,7 @@ import { addons } from "@storybook/preview-api"
 
 // allows to implement themed components in the storybook
 // component adjusts to the selected theme and enables tailwind classes.
-export function JunoComponentParent(props) {
+export function JunoComponentWrapper(props) {
   // returns nothing if there is no child
   if (!props.children) {
     return

--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -2,7 +2,7 @@ import { Meta, Controls } from "@storybook/blocks"
 import { ColorPalette } from "./ColorPalette/ColorPalette.jsx"
 import { JunoColorPalette } from "./ColorPalette/JunoColorPalette.jsx"
 import { Message } from "../components/Message/Message.component.js"
-import { JunoComponentParent } from "./JunoComponentParent/JunoComponentParent.jsx"
+import { JunoComponentWrapper } from "./JunoComponentWrapper/JunoComponentWrapper.jsx"
 
 <Meta title="Colors" />
 
@@ -14,17 +14,17 @@ The Juno UI component library is based on Tailwind CSS which means that all Tail
 
 Theme colors adjust according to the chosen theme (dark or light) automatically. So unless you are creating something like a chart you should try to avoid the straight up colors like juno-grey-... and instead stick to the theme colors (they always contain the word theme somewhere in the name).
 
-<JunoComponentParent>
+<JunoComponentWrapper>
   <ColorPalette theme="theme-dark" />
   <ColorPalette theme="theme-light" />
-</JunoComponentParent>
+</JunoComponentWrapper>
 
 ## Primary Colors
 
-<JunoComponentParent>
+<JunoComponentWrapper>
   <Message
     text="Do not use these colors! They are listed mostly for informational purposes. The only use case where the base colors might be used is for charts and the like. Otherwise stick to the theme colors above!"
     variant="warning"
   />
   <JunoColorPalette />
-</JunoComponentParent>
+</JunoComponentWrapper>

--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -14,9 +14,13 @@ The Juno UI component library is based on Tailwind CSS which means that all Tail
 
 Theme colors adjust according to the chosen theme (dark or light) automatically. So unless you are creating something like a chart you should try to avoid the straight up colors like juno-grey-... and instead stick to the theme colors (they always contain the word theme somewhere in the name).
 
-<ColorPalette theme="theme-dark" />
+<JunoComponentParent>
+  <ColorPalette theme="theme-dark" />
+</JunoComponentParent>
 
-<ColorPalette theme="theme-light" />
+<JunoComponentParent>
+  <ColorPalette theme="theme-light" />
+</JunoComponentParent>
 
 ## Primary Colors
 
@@ -27,4 +31,6 @@ Theme colors adjust according to the chosen theme (dark or light) automatically.
   />
 </JunoComponentParent>
 
-<JunoColorPalette />
+<JunoComponentParent>
+  <JunoColorPalette />
+</JunoComponentParent>

--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -26,8 +26,5 @@ Theme colors adjust according to the chosen theme (dark or light) automatically.
     text="Do not use these colors! They are listed mostly for informational purposes. The only use case where the base colors might be used is for charts and the like. Otherwise stick to the theme colors above!"
     variant="warning"
   />
-</JunoComponentParent>
-
-<JunoComponentParent>
   <JunoColorPalette />
 </JunoComponentParent>

--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -16,9 +16,6 @@ Theme colors adjust according to the chosen theme (dark or light) automatically.
 
 <JunoComponentParent>
   <ColorPalette theme="theme-dark" />
-</JunoComponentParent>
-
-<JunoComponentParent>
   <ColorPalette theme="theme-light" />
 </JunoComponentParent>
 

--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -2,7 +2,7 @@ import { Meta, Controls } from "@storybook/blocks"
 import { ColorPalette } from "./ColorPalette/ColorPalette.jsx"
 import { JunoColorPalette } from "./ColorPalette/JunoColorPalette.jsx"
 import { Message } from "../components/Message/Message.component.js"
-import { StyleProvider } from "../components/StyleProvider/StyleProvider.component.js"
+import { JunoComponentParent } from "./JunoComponentParent/JunoComponentParent.jsx"
 
 <Meta title="Colors" />
 
@@ -20,13 +20,11 @@ Theme colors adjust according to the chosen theme (dark or light) automatically.
 
 ## Primary Colors
 
-<div>
-  <StyleProvider key="juno-decorator" stylesWrapper="inline">
-    <Message
-      text="Do not use these colors! They are listed mostly for informational purposes. The only use case where the base colors might be used is for charts and the like. Otherwise stick to the theme colors above!"
-      variant="warning"
-    />
-  </StyleProvider>
-</div>
+<JunoComponentParent>
+  <Message
+    text="Do not use these colors! They are listed mostly for informational purposes. The only use case where the base colors might be used is for charts and the like. Otherwise stick to the theme colors above!"
+    variant="warning"
+  />
+</JunoComponentParent>
 
 <JunoColorPalette />

--- a/libs/juno-ui-components/src/docsHidden/examplePage.mdx
+++ b/libs/juno-ui-components/src/docsHidden/examplePage.mdx
@@ -2,7 +2,6 @@
 
 import { Meta, Canvas, Controls } from "@storybook/blocks"
 import * as Textarea from "../components/Textarea/Textarea.stories"
-import { ColorPalette } from "../docs/ColorPalette/ColorPalette.jsx"
 import imageUrl from "../docs/img/Schwan.jpg"
 
 import { Message } from "../components/Message/Message.component.js"
@@ -34,10 +33,6 @@ Juno is extending W3C Standards to provide a more versatile and developer-friend
     className="jn-mb-6 jn-mt-5 "
   />
 </JunoComponentParent>
-
-{/* You can also use the img tag or import other components */}
-
-<ColorPalette theme="theme-light" />
 
 {
 console.log("You can write JS in mdx with curly braces")

--- a/libs/juno-ui-components/src/docsHidden/examplePage.mdx
+++ b/libs/juno-ui-components/src/docsHidden/examplePage.mdx
@@ -6,7 +6,8 @@ import { ColorPalette } from "../docs/ColorPalette/ColorPalette.jsx"
 import imageUrl from "../docs/img/Schwan.jpg"
 
 import { Message } from "../components/Message/Message.component.js"
-import { StyleProvider } from "../components/StyleProvider/StyleProvider.component.js"
+
+import { JunoComponentParent } from "../docs/JunoComponentParent/JunoComponentParent.jsx"
 
 {/* The Metatag helps to sort the page in the Nav bar. Components/Introduction would name the page Introduction in the components folder */}
 
@@ -24,11 +25,15 @@ Juno is extending W3C Standards to provide a more versatile and developer-friend
 <Canvas of={Textarea.WithLabel} />
 ## Componenten
 
-<div>
-  <StyleProvider key="juno-decorator" stylesWrapper="inline">
-    <Message text="This is a component. Not a story." variant="warning" />
-  </StyleProvider>
-</div>
+{/* You can import JunoComponent with a JunoComponentParent beaware: you can use tailwind classes with the prefix: jn- */}
+
+<JunoComponentParent>
+  <Message
+    text="This is a component. Not a story."
+    variant="warning"
+    className="jn-mb-6 jn-mt-5 "
+  />
+</JunoComponentParent>
 
 {/* You can also use the img tag or import other components */}
 

--- a/libs/juno-ui-components/src/docsHidden/examplePage.mdx
+++ b/libs/juno-ui-components/src/docsHidden/examplePage.mdx
@@ -6,7 +6,7 @@ import imageUrl from "../docs/img/Schwan.jpg"
 
 import { Message } from "../components/Message/Message.component.js"
 
-import { JunoComponentParent } from "../docs/JunoComponentParent/JunoComponentParent.jsx"
+import { JunoComponentWrapper } from "../docs/JunoComponentWrapper/JunoComponentWrapper.jsx"
 
 {/* The Metatag helps to sort the page in the Nav bar. Components/Introduction would name the page Introduction in the components folder */}
 
@@ -24,15 +24,15 @@ Juno is extending W3C Standards to provide a more versatile and developer-friend
 <Canvas of={Textarea.WithLabel} />
 ## Componenten
 
-{/* You can import JunoComponent with a JunoComponentParent beaware: you can use tailwind classes with the prefix: jn- */}
+{/* You can import JunoComponent with a JunoComponentWrapper beaware: you can use tailwind classes with the prefix: jn- */}
 
-<JunoComponentParent>
+<JunoComponentWrapper>
   <Message
     text="This is a component. Not a story."
     variant="warning"
     className="jn-mb-6 jn-mt-5 "
   />
-</JunoComponentParent>
+</JunoComponentWrapper>
 
 {
 console.log("You can write JS in mdx with curly braces")


### PR DESCRIPTION
Added a the component JunoComponentParent for mdx files.  The component allows the usage of tailwind classes for the child components while also handling theme changes.

fixes #472 

added juno-red to allowlist #466 

Implemented JunoComponentParent in the example page and color-page and reducing boilerplate code in the other ColorPalette.

TBD: Renaming the component to ComponentParent  or ComponentWrapper 
