### PR TITLE
Modal improvements

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/Modal/Modal.component.js
+++ b/libs/juno-ui-components/src/components/Modal/Modal.component.js
@@ -78,6 +78,7 @@ By default, the modal will close (i.e. set its `open` state to false) once the u
 To make the modal less intrusive and effectively un-modal it, pass `closeOnBackdropClick`. This will close the modal when the user clicks the modal backdrop.
 */
 export const Modal = ({
+	ariaLabel,
 	cancelButtonIcon,
 	cancelButtonLabel,
 	confirmButtonIcon,
@@ -153,6 +154,8 @@ export const Modal = ({
 	
 	const modalRef = useRef(null)
 	
+	const theTitle = title || heading
+	
 	const modalTitleId = uniqueId()
 	
 	return (
@@ -170,8 +173,8 @@ export const Modal = ({
 									escapeDeactivates: () => {handleEsc()},
 								}}
 							>
-								<div className={`juno-modal ${sizeClass(size)} ${modalstyles} ${className}`} role="dialog" ref={modalRef} {...props} aria-labelledby={modalTitleId}>
-									<div className={`juno-modal-header ${headerstyles} ${ title || heading ? `jn-justify-between` : `jn-justify-end` }`}>
+								<div className={`juno-modal ${sizeClass(size)} ${modalstyles} ${className}`} role="dialog" ref={modalRef} {...props} aria-labelledby={theTitle && theTitle.length ? modalTitleId : null} aria-label={ariaLabel}>
+									<div className={`juno-modal-header ${headerstyles} ${ theTitle && theTitle.length ? `jn-justify-between` : `jn-justify-end` }`}>
 										{ title || heading ? <h1 className={`juno-modal-title ${titlestyles}`} id={modalTitleId}>{ title || heading }</h1> : "" }
 										{ isCloseable ? <Icon icon="close" onClick={ handleCancelClick }/> : "" }
 									</div>
@@ -205,12 +208,14 @@ export const Modal = ({
 }
 
 Modal.propTypes = {
-	/** The Modal size */
-	size: PropTypes.oneOf(["small", "large"]),
-	/** The title of the modal */
+	/** The aria-label of the modal. Use only if the modal does NOT have a `title` or `heading`.  */
+	ariaLabel: PropTypes.string,
+	/** The title of the modal. This will be rendering as the heading of the modal, and the modal's `arial-labelledby` attribute will reference the title/heading element. If the modal does not have `title` or `heading`, use `ariaLabel` to provide an accessible name for the modal. */
 	title: PropTypes.string,
 	/** Also the title of the modal, just for API flexibility. If both `title` and `heading` are passed, `title` will win. */
 	heading: PropTypes.string,
+	/** The Modal size */
+	size: PropTypes.oneOf(["small", "large"]),
 	/** Pass a label to render a confirm button and a Cancel button */
 	confirmButtonLabel: PropTypes.string,
 	/** Pass a label for the cancel button. Defaults to "Cancel" */
@@ -244,6 +249,7 @@ Modal.propTypes = {
 }
 
 Modal.defaultProps = {
+	ariaLabel: undefined,
 	size: "small",
 	title: "",
 	heading: "",

--- a/libs/juno-ui-components/src/components/Modal/Modal.stories.js
+++ b/libs/juno-ui-components/src/components/Modal/Modal.stories.js
@@ -63,9 +63,9 @@ export default {
 
 export const Default = Template.bind({})
 Default.args = {
-  children: [
+  children:
     <p>A default modal.</p>
-  ],
+  ,
 }
 
 export const LargeWithTitle = Template.bind({})

--- a/libs/juno-ui-components/src/components/Modal/Modal.stories.js
+++ b/libs/juno-ui-components/src/components/Modal/Modal.stories.js
@@ -74,9 +74,8 @@ LargeWithTitle.args = {
   title: "Large Modal",
   confirmButtonLabel: "OK",
   closeOnConfirm: true, /* Only relevant for storybook, this is not a native prop of the component! */
-  children: [
-    <p>A large modal with a title</p>
-  ]
+  children: 
+    <p>A large modal with a title</p>,
 }
 
 export const NonCloseable = Template.bind({})

--- a/libs/juno-ui-components/src/components/Modal/Modal.stories.js
+++ b/libs/juno-ui-components/src/components/Modal/Modal.stories.js
@@ -68,6 +68,14 @@ Default.args = {
   ,
 }
 
+export const SimpleConfirmDialog = Template.bind({})
+SimpleConfirmDialog.args = {
+  children: 
+    <p>Are you sure you want to proceed?</p>,
+  cancelButtonLabel: "Cancel",
+  confirmButtonLabel: "Yes, Proceed"
+}
+
 export const LargeWithTitle = Template.bind({})
 LargeWithTitle.args = {
   size: "large",

--- a/libs/juno-ui-components/src/components/Modal/Modal.test.js
+++ b/libs/juno-ui-components/src/components/Modal/Modal.test.js
@@ -26,6 +26,36 @@ describe("Modal", () => {
 	  expect(screen.getByRole("dialog")).toBeInTheDocument()
 	  expect(screen.getByRole("dialog")).toHaveTextContent("My Modal")
   })
+	
+	test("renders a title when a 'heading' prop is passed", async () => {
+		render(<PortalProvider><Modal heading="My Modal Heading" open /></PortalProvider>)
+		expect(screen.getByRole("dialog")).toBeInTheDocument()
+		expect(screen.getByRole("dialog")).toHaveTextContent("My Modal Heading")
+	})
+	
+	test("renders an aria-labelledby attribute referencing the title if passed", async () => {
+		render(<PortalProvider><Modal title="My a11y Modal" open /></PortalProvider>)
+		expect(screen.getByRole("dialog")).toBeInTheDocument()
+		const modalTitle = screen.getByText("My a11y Modal")
+		expect(modalTitle).toHaveAttribute("id")
+		const modalTitleId = modalTitle.getAttribute("id")
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-labelledby", modalTitleId)
+	})
+	
+	test("renders an aria-labelledby attribute referencing the heading if passed", async () => {
+		render(<PortalProvider><Modal title="My other a11y Modal" open /></PortalProvider>)
+		expect(screen.getByRole("dialog")).toBeInTheDocument()
+		const modalTitle = screen.getByText("My other a11y Modal")
+		expect(modalTitle).toHaveAttribute("id")
+		const modalTitleId = modalTitle.getAttribute("id")
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-labelledby", modalTitleId)
+	})
+	
+	test("renders an arial-label attribute as passed", async () => {
+		render(<PortalProvider><Modal ariaLabel="Otherwise unnamed modal" open /></PortalProvider>)
+		expect(screen.getByRole("dialog")).toBeInTheDocument()
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "Otherwise unnamed modal")
+	})
   
   test("renders children as passed", async () => {
 	  render(


### PR DESCRIPTION
* render `aria-labelledby` only if the modal has a heading that can be referenced, i.e. `title` or `heading` have been passed.
* add `ariaLabel` prop so there is an explicit way to add an accessible name to a modal even if it does not have a heading or title
* fix some story args to remove console errors