### PR TITLE
[supernova] Tests for the filter compontent and corrected expected behaviour.

### DIFF
--- a/apps/supernova/package.json
+++ b/apps/supernova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supernova",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": "Juno team (SAP)",
   "license": "MIT",
   "source": "src/index.js",

--- a/apps/supernova/src/lib/createFiltersSlice.js
+++ b/apps/supernova/src/lib/createFiltersSlice.js
@@ -18,15 +18,20 @@ const createFiltersSlice = (set, get) => ({
           (state) => {
             if (!labels) return state
 
-            // check if labels is an array and if every element in the array is a string
-            if (
-              !Array.isArray(labels) ||
-              !labels.some((element) => typeof element === "string")
-            ) {
+            // check if labels is an array
+            if (!Array.isArray(labels)) {
               console.warn(
-                "[supernova]::setLabels: labels object is not an array of strings"
+                "[supernova]::setLabels: labels object is not an array"
               )
               return state
+            }
+
+            // check if all elements in the array are strings delete the ones that are not
+            if (!labels.every((element) => typeof element === "string")) {
+              console.warn(
+                "[supernova]::setLabels: Some Array elements are not strings."
+              )
+              labels = labels.filter((element) => typeof element === "string")
             }
 
             // merge given labels with the initial, make it unique and sort it alphabetically

--- a/apps/supernova/src/lib/createFiltersSlice.js
+++ b/apps/supernova/src/lib/createFiltersSlice.js
@@ -29,7 +29,7 @@ const createFiltersSlice = (set, get) => ({
             // check if all elements in the array are strings delete the ones that are not
             if (!labels.every((element) => typeof element === "string")) {
               console.warn(
-                "[supernova]::setLabels: Some Array elements are not strings."
+                "[supernova]::setLabels: Some elements of the array are not strings."
               )
               labels = labels.filter((element) => typeof element === "string")
             }

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -119,7 +119,7 @@ describe("createFiltersSlice", () => {
       spy.mockRestore()
     })
 
-    it("warns the user if labels also includes non-strings", () => {
+    it("warns the user if labels array also includes non-strings and adds the valid labels", () => {
       const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
 
       const wrapper = ({ children }) => (
@@ -135,11 +135,17 @@ describe("createFiltersSlice", () => {
 
       act(() => store.result.current.actions.setLabels(["app", 1, 9]))
 
+      // Is the warning called?
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(
         "[supernova]::setLabels: Some elements of the array are not strings."
       )
       spy.mockRestore()
+
+      // Are valid labels still set?
+      expect(store.result.current.filterLabels).toEqual(
+        expect.arrayContaining(["app", "status"])
+      )
     })
   })
 

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -71,7 +71,7 @@ describe("createFiltersSlice", () => {
       )
     })
 
-    it("Adds empty array to dropdown", () => {
+    it("Adds empty array to select", () => {
       const wrapper = ({ children }) => (
         <StoreProvider>{children}</StoreProvider>
       )

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -25,7 +25,7 @@ describe("createFiltersSlice", () => {
       expect(store.result.current.filterLabels).toEqual(["status"])
     })
 
-    it("just accepts array of strings", () => {
+    it("Adds array to dropdown", () => {
       const wrapper = ({ children }) => (
         <StoreProvider>{children}</StoreProvider>
       )
@@ -53,20 +53,22 @@ describe("createFiltersSlice", () => {
         ])
       })
 
-      expect(store.result.current.filterLabels).toEqual([
-        "app",
-        "cluster",
-        "cluster_type",
-        "context",
-        "job",
-        "region",
-        "service",
-        "severity",
-        "status",
-        "support_group",
-        "tier",
-        "type",
-      ])
+      expect(store.result.current.filterLabels).toEqual(
+        expect.arrayContaining([
+          "app",
+          "status",
+          "cluster",
+          "cluster_type",
+          "context",
+          "job",
+          "region",
+          "service",
+          "severity",
+          "support_group",
+          "tier",
+          "type",
+        ])
+      )
     })
 
     it("warn the user if labels are different then an array of strings", () => {
@@ -96,6 +98,7 @@ describe("createFiltersSlice", () => {
       spy.mockRestore()
     })
   })
+
   describe("setSearchTerm", () => {
     it("empty search term", () => {
       const wrapper = ({ children }) => (

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -25,7 +25,7 @@ describe("createFiltersSlice", () => {
       expect(store.result.current.filterLabels).toEqual(["status"])
     })
 
-    it("Adds array to dropdown", () => {
+    it("Adds array with strings to dropdown", () => {
       const wrapper = ({ children }) => (
         <StoreProvider>{children}</StoreProvider>
       )
@@ -71,7 +71,28 @@ describe("createFiltersSlice", () => {
       )
     })
 
-    it("warn the user if labels are different then an array of strings", () => {
+    it("Adds empty array to dropdown", () => {
+      const wrapper = ({ children }) => (
+        <StoreProvider>{children}</StoreProvider>
+      )
+      const store = renderHook(
+        () => ({
+          actions: useFilterActions(),
+          filterLabels: useFilterLabels(),
+        }),
+        { wrapper }
+      )
+
+      act(() => {
+        store.result.current.actions.setLabels([])
+      })
+
+      expect(store.result.current.filterLabels).toEqual(
+        expect.arrayContaining(["status"])
+      )
+    })
+
+    it("warn the user if labels are not an array", () => {
       const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
 
       const wrapper = ({ children }) => (
@@ -93,7 +114,30 @@ describe("createFiltersSlice", () => {
 
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(
-        "[supernova]::setLabels: labels object is not an array of strings"
+        "[supernova]::setLabels: labels object is not an array"
+      )
+      spy.mockRestore()
+    })
+
+    it("warn the user if labels have also interger instead of an array of strings", () => {
+      const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+      const wrapper = ({ children }) => (
+        <StoreProvider>{children}</StoreProvider>
+      )
+      const store = renderHook(
+        () => ({
+          actions: useFilterActions(),
+          filterLabels: useFilterLabels(),
+        }),
+        { wrapper }
+      )
+
+      act(() => store.result.current.actions.setLabels(["app", 1, 9]))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith(
+        "[supernova]::setLabels: Some Array elements are not strings."
       )
       spy.mockRestore()
     })

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -92,7 +92,7 @@ describe("createFiltersSlice", () => {
       )
     })
 
-    it("warn the user if labels are not an array", () => {
+    it("warns the user if labels are not an array", () => {
       const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
 
       const wrapper = ({ children }) => (
@@ -119,7 +119,7 @@ describe("createFiltersSlice", () => {
       spy.mockRestore()
     })
 
-    it("warn the user if labels have also interger instead of an array of strings", () => {
+    it("warns the user if labels also includes non-strings", () => {
       const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
 
       const wrapper = ({ children }) => (
@@ -137,7 +137,7 @@ describe("createFiltersSlice", () => {
 
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(
-        "[supernova]::setLabels: Some Array elements are not strings."
+        "[supernova]::setLabels: Some elements of the array are not strings."
       )
       spy.mockRestore()
     })

--- a/apps/supernova/src/lib/createFiltersSlice.test.js
+++ b/apps/supernova/src/lib/createFiltersSlice.test.js
@@ -25,7 +25,7 @@ describe("createFiltersSlice", () => {
       expect(store.result.current.filterLabels).toEqual(["status"])
     })
 
-    it("Adds array with strings to dropdown", () => {
+    it("Adds array with strings to select", () => {
       const wrapper = ({ children }) => (
         <StoreProvider>{children}</StoreProvider>
       )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1284,7 +1284,7 @@
       }
     },
     "apps/supernova": {
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.2",


### PR DESCRIPTION
Supernova don't crash when there are labels which are not a string. Instead it ignores these labels. This behaviour is also tested.