### PR TITLE
[greenhouse-mgmt] Ensure unmounting of plugIns and reading of URL

### DIFF
--- a/apps/greenhouse-management/src/components/Plugin.jsx
+++ b/apps/greenhouse-management/src/components/Plugin.jsx
@@ -50,7 +50,6 @@ const Plugin = ({ config }) => {
       // remove from holder
       mountApp.then((loaded) => {
         if (!loaded) return
-
         if (holder.current.contains(app.current))
           holder.current.removeChild(app.current)
       })

--- a/apps/greenhouse-management/src/components/Plugin.jsx
+++ b/apps/greenhouse-management/src/components/Plugin.jsx
@@ -13,6 +13,10 @@ const Plugin = ({ config }) => {
   const activePlugin = usePluginActive()
   const [displayReload, setDisplayReload] = useState(false)
   const [reload, setReload] = useState(0)
+  /* State isMounted is to ensure that plugin isMounted before unmounting.
+   * Otherwise delays in mountApp can overtake the unmounting resulting in not unmounting the plugin.
+   */
+  const [isMounted, setMounted] = useState(false)
 
   const el = document.createElement("div")
   el.classList.add("inline")
@@ -40,21 +44,19 @@ const Plugin = ({ config }) => {
   useEffect(() => {
     // if assetsUrl still null when rendering for first time the component then mountApp also return null and we skip here
     if (!mountApp) return
-
     if (displayPluging) {
       mountApp.then((loaded) => {
         if (!loaded) return
         holder.current.appendChild(app.current)
+        setMounted(true)
       })
     } else {
       // remove from holder
-      mountApp.then((loaded) => {
-        if (!loaded) return
-        if (holder.current.contains(app.current))
-          holder.current.removeChild(app.current)
-      })
+      if (holder.current.contains(app.current) && isMounted)
+        holder.current.removeChild(app.current)
+      setMounted(false)
     }
-  }, [mountApp, displayPluging])
+  }, [mountApp, displayPluging, isMounted])
 
   return (
     <div data-app={config?.name} ref={holder} className="inline">

--- a/apps/greenhouse-management/src/components/Plugin.jsx
+++ b/apps/greenhouse-management/src/components/Plugin.jsx
@@ -41,15 +41,33 @@ const Plugin = ({ config }) => {
     // if assetsUrl still null when rendering for first time the component then mountApp also return null and we skip here
     if (!mountApp) return
 
+    if (config?.name === "greenhouse-cluster-admin") {
+      console.log(
+        "Plugin",
+        config?.name,
+        "displayPluging",
+        displayPluging,
+        "activePlugin",
+        activePlugin
+      )
+    }
+
     if (displayPluging) {
       mountApp.then((loaded) => {
         if (!loaded) return
         holder.current.appendChild(app.current)
+        console.log("Plugin mounted: ", config?.name)
       })
     } else {
       // remove from holder
-      if (holder.current.contains(app.current))
-        holder.current.removeChild(app.current)
+      mountApp.then((loaded) => {
+        if (!loaded) return
+
+        if (holder.current.contains(app.current))
+          holder.current.removeChild(app.current)
+      })
+
+      console.log("Plugin unmounted: ", config?.name)
     }
   }, [mountApp, displayPluging])
 

--- a/apps/greenhouse-management/src/components/Plugin.jsx
+++ b/apps/greenhouse-management/src/components/Plugin.jsx
@@ -41,22 +41,10 @@ const Plugin = ({ config }) => {
     // if assetsUrl still null when rendering for first time the component then mountApp also return null and we skip here
     if (!mountApp) return
 
-    if (config?.name === "greenhouse-cluster-admin") {
-      console.log(
-        "Plugin",
-        config?.name,
-        "displayPluging",
-        displayPluging,
-        "activePlugin",
-        activePlugin
-      )
-    }
-
     if (displayPluging) {
       mountApp.then((loaded) => {
         if (!loaded) return
         holder.current.appendChild(app.current)
-        console.log("Plugin mounted: ", config?.name)
       })
     } else {
       // remove from holder
@@ -66,8 +54,6 @@ const Plugin = ({ config }) => {
         if (holder.current.contains(app.current))
           holder.current.removeChild(app.current)
       })
-
-      console.log("Plugin unmounted: ", config?.name)
     }
   }, [mountApp, displayPluging])
 

--- a/apps/greenhouse-management/src/components/SideNav.js
+++ b/apps/greenhouse-management/src/components/SideNav.js
@@ -5,7 +5,6 @@ import { usePluginConfig, usePluginActive, useActions } from "./StoreProvider"
 const SideNav = () => {
   const pluginConfig = usePluginConfig()
   const pluginActive = usePluginActive()
-
   const { setPluginActive } = useActions()
 
   return (

--- a/apps/greenhouse-management/src/components/SideNav.js
+++ b/apps/greenhouse-management/src/components/SideNav.js
@@ -5,15 +5,16 @@ import { usePluginConfig, usePluginActive, useActions } from "./StoreProvider"
 const SideNav = () => {
   const pluginConfig = usePluginConfig()
   const pluginActive = usePluginActive()
+
   const { setPluginActive } = useActions()
 
   return (
-    <SideNavigation>
+    <SideNavigation activeItem={pluginActive}>
       {Object.keys(pluginConfig).map((key, index) => (
         <SideNavigationItem
           key={index}
           label={pluginConfig[key]?.label}
-          active={pluginConfig[key]?.name === pluginActive}
+          value={pluginConfig[key]?.name}
           onClick={() => setPluginActive(pluginConfig[key]?.name)}
         />
       ))}

--- a/apps/greenhouse-management/src/hooks/useUrlState.js
+++ b/apps/greenhouse-management/src/hooks/useUrlState.js
@@ -1,7 +1,8 @@
-import { useEffect, useLayoutEffect } from "react"
+import { useEffect, useState, useLayoutEffect } from "react"
 import { registerConsumer } from "url-state-provider"
 import {
   useActions,
+  useIsLoggedIn,
   useIsUrlStateSetup,
   usePluginActive,
 } from "../components/StoreProvider"
@@ -13,22 +14,23 @@ const urlStateManager = registerConsumer(URL_APP_STATE_KEY)
 
 const useUrlState = () => {
   const { setPluginActive, setIsUrlStateSetup } = useActions()
+  const [isURLRead, setIsURLRead] = useState(false)
   const isUrlStateSetup = useIsUrlStateSetup()
   const pluginActive = usePluginActive()
+  const isLoggedIn = useIsLoggedIn()
 
-  // Initial state from URL AFTER
-  // WARNING. To get the right state from the URL do following:
-  // If this app is embbeded in another app with authentication
-  //  - Mount this app after the login is success in the parent app
-  // or
-  //  - Wait here until you get logged in
   useLayoutEffect(() => {
+    // just read the url state once, after the user is logged in
+    if (!isLoggedIn || isURLRead) return
+
     if (isUrlStateSetup) return
 
     let active = urlStateManager.currentState()?.[ACTIVE_APP_KEY]
     if (active) setPluginActive(active)
     setIsUrlStateSetup(true)
-  }, [isUrlStateSetup])
+
+    setIsURLRead(true)
+  }, [isUrlStateSetup, isLoggedIn])
 
   // sync URL state
   useEffect(() => {

--- a/apps/greenhouse/package.json
+++ b/apps/greenhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "managementVersion": "latest",
   "author": "Juno team (SAP)",
   "license": "MIT",

--- a/apps/greenhouse/src/components/Plugin.jsx
+++ b/apps/greenhouse/src/components/Plugin.jsx
@@ -15,6 +15,11 @@ const Plugin = ({ id }) => {
   const [displayReload, setDisplayReload] = useState(false)
   const [reload, setReload] = useState(0)
 
+  /* State isMounted is to ensure that plugin isMounted before unmounting.
+   * Otherwise delays in mountApp can overtake the unmounting resulting in not unmounting the plugin in edgecases.
+   */
+  const [isMounted, setMounted] = useState(false)
+
   const el = document.createElement("div")
   el.classList.add("inline")
   const app = useRef(el)
@@ -50,13 +55,16 @@ const Plugin = ({ id }) => {
       mountApp.then((loaded) => {
         if (!loaded) return
         holder.current.appendChild(app.current)
+        setMounted(true)
       })
     } else {
       // remove from holder
-      if (holder.current.contains(app.current))
+      if (holder.current.contains(app.current) && !isMounted)
         holder.current.removeChild(app.current)
+
+      setMounted(false)
     }
-  }, [mountApp, displayPluging])
+  }, [mountApp, displayPluging, isMounted])
 
   return (
     <div data-app={id} ref={holder} className="inline">

--- a/apps/greenhouse/src/components/PluginContainer.jsx
+++ b/apps/greenhouse/src/components/PluginContainer.jsx
@@ -48,13 +48,17 @@ const PluginContainer = () => {
   return (
     <>
       {isFetching && <HintLoading text="Loading plugins..." />}
-      {displayPlugin && availableAppIds.length > 0
-        ? availableAppIds.map((id, i) => (
-            <MessagesProvider key={i}>
-              <Plugin id={id} />
-            </MessagesProvider>
-          ))
-        : "No plugins available"}
+      {displayPlugin &&
+        availableAppIds.length > 0 &&
+        availableAppIds.map((id, i) => (
+          <MessagesProvider key={i}>
+            <Plugin id={id} />
+          </MessagesProvider>
+        ))}
+      {!isFetching &&
+        !displayPlugin &&
+        availableAppIds.length <= 0 &&
+        "No plugins available."}
     </>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,7 +348,7 @@
       }
     },
     "apps/greenhouse-management": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,7 +298,7 @@
       }
     },
     "apps/greenhouse": {
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.2",


### PR DESCRIPTION
fixes #522 #521 #532 and Navigation

#522 useURLState is executed after logged in.
#532 Tabs now unmount even if unmounting is trigged before mounting is done. (greenhouse + greenhouse-mgmt) 
Fix 3: Navigation items are now reacting to state changes not triggered by themselves.
