### PR TITLE
[juno-ui-components]: fixed reseting active attribute in SideNavigationItem and TabNavigationItem. Added tests with rerender function.

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/SideNavigation/SideNavigation.test.js
+++ b/libs/juno-ui-components/src/components/SideNavigation/SideNavigation.test.js
@@ -1,24 +1,23 @@
-import * as React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { SideNavigation } from './index';
-import { SideNavigationItem } from '../SideNavigationItem/index';
+import * as React from "react"
+import { render, screen, waitFor, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { SideNavigation } from "./index"
+import { SideNavigationItem } from "../SideNavigationItem/index"
 
 const mockOnActiveItemChange = jest.fn()
 
-describe('SideNavigation', () => {
-  
+describe("SideNavigation", () => {
   afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
+    cleanup()
+    jest.clearAllMocks()
   })
-  
-  test('render a SideNavigation', async () => {
-    render(<SideNavigation />);
-    expect(screen.getByRole('navigation')).toBeInTheDocument();
-    expect(screen.getByRole('navigation')).toHaveClass("juno-sidenavigation");
-  });
-  
+
+  test("render a SideNavigation", async () => {
+    render(<SideNavigation />)
+    expect(screen.getByRole("navigation")).toBeInTheDocument()
+    expect(screen.getByRole("navigation")).toHaveClass("juno-sidenavigation")
+  })
+
   test("renders children as passed", async () => {
     render(
       <SideNavigation>
@@ -29,50 +28,70 @@ describe('SideNavigation', () => {
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(3)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 3"})).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 3" })).toBeInTheDocument()
   })
-  
+
   test("renders an aria-label as passed", async () => {
     render(<SideNavigation ariaLabel="describe the navigation" />)
     expect(screen.getByRole("navigation")).toBeInTheDocument()
-    expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "describe the navigation")
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-label",
+      "describe the navigation"
+    )
   })
-  
+
   test("renders disabled children as passed", async () => {
     render(
       <SideNavigation disabled>
         <SideNavigationItem label="Item 1" />
         <SideNavigationItem label="Item 2" />
-      </SideNavigation>)
-      expect(screen.getByRole("navigation")).toBeInTheDocument()
-      expect(screen.queryAllByRole("button")).toHaveLength(2)
-      expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 1"})).toBeDisabled()
-      expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-disabled", "true")
-      expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 2"})).toBeDisabled()
-      expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-disabled", "true")
+      </SideNavigation>
+    )
+    expect(screen.getByRole("navigation")).toBeInTheDocument()
+    expect(screen.queryAllByRole("button")).toHaveLength(2)
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
-  
+
   test("renders an active navigation item as passed", async () => {
     render(
       <SideNavigation activeItem="Item 2">
         <SideNavigationItem label="Item 1" />
         <SideNavigationItem label="Item 2" />
       </SideNavigation>
-      )
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 1"})).not.toHaveClass("juno-sidenavigation-item-active")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveClass("juno-sidenavigation-item-active")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
   })
-  
+
   test("renders an active navigation item as passed by value", async () => {
     render(
       <SideNavigation activeItem="i-2">
@@ -82,31 +101,113 @@ describe('SideNavigation', () => {
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 1"})).not.toHaveClass("juno-sidenavigation-item-active")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveClass("juno-sidenavigation-item-active")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
   })
-  
+
   test("renders the active item as passed to the parent if conflicting with active prop passed to child item", async () => {
     render(
       <SideNavigation activeItem="Item 2">
-        <SideNavigationItem label="Item 1" active/>
+        <SideNavigationItem label="Item 1" active />
         <SideNavigationItem label="Item 2" />
-        </SideNavigation>
+      </SideNavigation>
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 1"})).not.toHaveClass("juno-sidenavigation-item-active")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveClass("juno-sidenavigation-item-active")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
   })
-  
+
+  test("rerenders the active item as passed to the parent if conflicting with new state of active prop passed to child item", async () => {
+    const { rerender } = render(
+      <SideNavigation activeItem="Item 2">
+        <SideNavigationItem label="Item 1" />
+        <SideNavigationItem label="Item 2" />
+      </SideNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    rerender(
+      <SideNavigation activeItem="Item 1">
+        <SideNavigationItem label="Item 1" />
+        <SideNavigationItem label="Item 2" />
+      </SideNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+  })
+
+  test("rerenders the active item as passed to the parent if conflicting with new state of active prop passed to child item", async () => {
+    const { rerender } = render(
+      <SideNavigation activeItem="Item 2">
+        <SideNavigationItem label="Item 1" active />
+        <SideNavigationItem label="Item 2" />
+        <SideNavigationItem label="Item 3" />
+      </SideNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 3" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    rerender(
+      <SideNavigation activeItem="Item 2">
+        <SideNavigationItem label="Item 1" />
+        <SideNavigationItem label="Item 2" />
+        <SideNavigationItem label="Item 3" active />
+      </SideNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 3" })).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+  })
+
   test("changes the active item when the user clicks", async () => {
     render(
       <SideNavigation activeItem="Item 1">
@@ -116,8 +217,8 @@ describe('SideNavigation', () => {
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    const tab1 = screen.getByRole("button", {name: "Item 1"})
-    const tab2 = screen.getByRole("button", {name: "Item 2"})
+    const tab1 = screen.getByRole("button", { name: "Item 1" })
+    const tab2 = screen.getByRole("button", { name: "Item 2" })
     expect(tab1).toHaveAttribute("aria-selected", "true")
     expect(tab1).toHaveClass("juno-sidenavigation-item-active")
     expect(tab2).toHaveAttribute("aria-selected", "false")
@@ -128,27 +229,34 @@ describe('SideNavigation', () => {
     expect(tab2).toHaveAttribute("aria-selected", "true")
     expect(tab2).toHaveClass("juno-sidenavigation-item-active")
   })
-  
+
   test("executes a handler as passed when the selected item changes", async () => {
     render(
-      <SideNavigation activeItem="Item 1" onActiveItemChange={mockOnActiveItemChange}>
+      <SideNavigation
+        activeItem="Item 1"
+        onActiveItemChange={mockOnActiveItemChange}
+      >
         <SideNavigationItem label="Item 1" />
         <SideNavigationItem label="Item 2" />
-      </SideNavigation>)
+      </SideNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    const item2 = screen.getByRole("button", {name: "Item 2"})
+    const item2 = screen.getByRole("button", { name: "Item 2" })
     await userEvent.click(item2)
     expect(mockOnActiveItemChange).toHaveBeenCalled()
   })
 
-  test('renders custom classNames as passed', async () => {
-    render(<SideNavigation className='my-custom-class' />);
-    expect(screen.getByRole("navigation")).toHaveClass('my-custom-class');
-  });
+  test("renders custom classNames as passed", async () => {
+    render(<SideNavigation className="my-custom-class" />)
+    expect(screen.getByRole("navigation")).toHaveClass("my-custom-class")
+  })
 
-  test('renders all props as passed', async () => {
-    render(<SideNavigation data-lol='Prop goes here' />);
-    expect(screen.getByRole('navigation')).toHaveAttribute('data-lol', 'Prop goes here');
-  });
-});
+  test("renders all props as passed", async () => {
+    render(<SideNavigation data-lol="Prop goes here" />)
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "data-lol",
+      "Prop goes here"
+    )
+  })
+})

--- a/libs/juno-ui-components/src/components/SideNavigationItem/SideNavigationItem.component.js
+++ b/libs/juno-ui-components/src/components/SideNavigationItem/SideNavigationItem.component.js
@@ -1,9 +1,8 @@
-import React, { useContext, useEffect, useState} from "react";
-import PropTypes from "prop-types";
+import React, { useContext, useEffect, useState } from "react"
+import PropTypes from "prop-types"
 import { NavigationContext } from "../SideNavigation/SideNavigation.component"
-import { Icon } from "../Icon/index.js";
+import { Icon } from "../Icon/index.js"
 import { knownIcons } from "../Icon/Icon.component.js"
-
 
 const itemStyles = `
   jn-flex
@@ -46,100 +45,114 @@ export const SideNavigationItem = ({
   value,
   ...props
 }) => {
-  
   const navigationContext = useContext(NavigationContext)
-  
+
   const {
     activeItem: activeItem,
     updateActiveItem: updateActiveItem,
     handleActiveItemChange: handleActiveItemChange,
     disabled: groupDisabled,
   } = navigationContext || {}
-  
+
   const theKey = value || label
-  
+
   const initialActive = () => {
-    if (navigationContext) {
-      activeItem === theKey ? true : false
+    if (navigationContext?.activeItem?.length > 0) {
+      return activeItem === theKey
     } else {
       return active
     }
   }
-  
-  const [isActive, setIsActive] = useState( () => initialActive() )
-  
-  // Set the parent state once if not set on the parent, but a navigation item has been set to active via its own prop:
-  useEffect(() => {
-    if (active && navigationContext && !activeItem) {
-      updateActiveItem(theKey)
-    }
-  }, [])
-  
+
+  const [isActive, setIsActive] = useState(() => initialActive())
+
   // Update the parent state when in a navigation context, otherwise update item state directly:
   useEffect(() => {
     if (activeItem) {
       activeItem === theKey ? setIsActive(true) : setIsActive(false)
-    } else {
-      setIsActive(active)
+      return
     }
+    setIsActive(active)
   }, [activeItem, active])
-  
-  
+
   const handleItemClick = (event) => {
     if (!isActive) {
       handleActiveItemChange(theKey)
     }
     onClick && onClick(event)
   }
-  
+
   return (
     <li className="jn-flex">
-      { href ? 
-          <a 
-            className={`
+      {href ? (
+        <a
+          className={`
               juno-sidenavigation-item
-              ${ itemStyles}
-              ${ isActive ? "juno-sidenavigation-item-active" : ""}
-              ${ isActive ? activeItemStyles : ""}
-              ${ disabled || groupDisabled ? disabledItemStyles : ""}
-              ${ disabled || groupDisabled ? "juno-sidenavigation-item-disabled" : ""}
-              ${ className }
+              ${itemStyles}
+              ${isActive ? "juno-sidenavigation-item-active" : ""}
+              ${isActive ? activeItemStyles : ""}
+              ${disabled || groupDisabled ? disabledItemStyles : ""}
+              ${
+                disabled || groupDisabled
+                  ? "juno-sidenavigation-item-disabled"
+                  : ""
+              }
+              ${className}
             `}
-            href={href}
-            aria-label={ariaLabel}
-            aria-disabled={ disabled || groupDisabled ? true : false}
-            aria-selected={isActive}
-            onClick={handleItemClick}
-            {...props}
-          >
-            { icon ? <Icon icon={icon} size="18" className={ label && label.length ? "jn-mr-2" : "" } /> : "" }
-            <span>{ children || label || theKey }</span>
-          </a>
-        :
-          <button
-            className={`
+          href={href}
+          aria-label={ariaLabel}
+          aria-disabled={disabled || groupDisabled ? true : false}
+          aria-selected={isActive}
+          onClick={handleItemClick}
+          {...props}
+        >
+          {icon ? (
+            <Icon
+              icon={icon}
+              size="18"
+              className={label && label.length ? "jn-mr-2" : ""}
+            />
+          ) : (
+            ""
+          )}
+          <span>{children || label || theKey}</span>
+        </a>
+      ) : (
+        <button
+          className={`
               juno-sidenavigation-item
-              ${ itemStyles}
-              ${ isActive ? "juno-sidenavigation-item-active" : ""}
-              ${ isActive ? activeItemStyles : ""}
-              ${ disabled || groupDisabled ? disabledItemStyles : ""}
-              ${ disabled || groupDisabled ? "juno-sidenavigation-item-disabled" : ""}
-              ${ className }
+              ${itemStyles}
+              ${isActive ? "juno-sidenavigation-item-active" : ""}
+              ${isActive ? activeItemStyles : ""}
+              ${disabled || groupDisabled ? disabledItemStyles : ""}
+              ${
+                disabled || groupDisabled
+                  ? "juno-sidenavigation-item-disabled"
+                  : ""
+              }
+              ${className}
             `}
-            aria-label={ariaLabel}
-            aria-disabled={ disabled || groupDisabled ? true : false}
-            aria-selected={isActive}
-            disabled={disabled || groupDisabled ? true : false }
-            onClick={handleItemClick}
-            {...props}
-          >
-            { icon ? <Icon icon={icon} size="18" className={ label && label.length ? "jn-mr-2" : "" } /> : "" }
-            <span>{ children || label || theKey }</span>
-          </button>
-      }
+          aria-label={ariaLabel}
+          aria-disabled={disabled || groupDisabled ? true : false}
+          aria-selected={isActive}
+          disabled={disabled || groupDisabled ? true : false}
+          onClick={handleItemClick}
+          {...props}
+        >
+          {icon ? (
+            <Icon
+              icon={icon}
+              size="18"
+              className={label && label.length ? "jn-mr-2" : ""}
+            />
+          ) : (
+            ""
+          )}
+          <span>{children || label || theKey}</span>
+        </button>
+      )}
     </li>
   )
-  
 }
 
 SideNavigationItem.propTypes = {
@@ -163,7 +176,7 @@ SideNavigationItem.propTypes = {
   href: PropTypes.string,
   /** A handler to execute once the item is clicked. Will render the item as a button element if passed */
   onClick: PropTypes.func,
-  /** An optional technical identifier fort the tab. If not passed, the label will be used to identify the tab. NOTE: If value is passed, the value of the active tab MUST be used when setting the activeItem prop on the parent SideNavigation.*/ 
+  /** An optional technical identifier fort the tab. If not passed, the label will be used to identify the tab. NOTE: If value is passed, the value of the active tab MUST be used when setting the activeItem prop on the parent SideNavigation.*/
   value: PropTypes.string,
 }
 

--- a/libs/juno-ui-components/src/components/SideNavigationItem/SideNavigationItem.test.js
+++ b/libs/juno-ui-components/src/components/SideNavigationItem/SideNavigationItem.test.js
@@ -1,98 +1,147 @@
-import * as React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { SideNavigation } from '../SideNavigation/index';
-import { SideNavigationItem } from './index';
+import * as React from "react"
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  rerender,
+} from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { SideNavigation } from "../SideNavigation/index"
+import { SideNavigationItem } from "./index"
 
 const mockOnClick = jest.fn()
 
-describe('SideNavigationItem', () => {
-  
+describe("SideNavigationItem", () => {
   afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
+    cleanup()
+    jest.clearAllMocks()
   })
-  
-  test('renders a SideNavigationItem', async () => {
-    render(<SideNavigationItem data-testid="side-nav-item" />);
-    expect(screen.getByTestId('side-nav-item')).toBeInTheDocument();
-    expect(screen.getByTestId('side-nav-item')).toHaveClass("juno-sidenavigation-item");
+
+  test("renders a SideNavigationItem", async () => {
+    render(<SideNavigationItem data-testid="side-nav-item" />)
+    expect(screen.getByTestId("side-nav-item")).toBeInTheDocument()
+    expect(screen.getByTestId("side-nav-item")).toHaveClass(
+      "juno-sidenavigation-item"
+    )
   })
-  
+
   test("renders a label as passed", async () => {
     render(<SideNavigationItem label="My Label" />)
-    expect(screen.getByRole("button")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveTextContent("My Label");
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveTextContent("My Label")
   })
-  
+
   test("renders children as passed", async () => {
     render(<SideNavigationItem>The Item Is A Child</SideNavigationItem>)
-    expect(screen.getByRole("button")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveTextContent("The Item Is A Child");
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveTextContent("The Item Is A Child")
   })
-  
+
   test("renders an aria-label as passed", async () => {
     render(<SideNavigationItem ariaLabel="My ARIA-Label" />)
     expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "My ARIA-Label")
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "My ARIA-Label"
+    )
   })
-  
+
   test("renders a disabled item as passed", async () => {
     render(<SideNavigationItem disabled />)
     expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toBeDisabled();
-    expect(screen.getByRole("button")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("button")).toBeDisabled()
+    expect(screen.getByRole("button")).toHaveAttribute("aria-disabled", "true")
   })
-  
+
   test("renders an icon as passed", async () => {
     render(<SideNavigationItem icon="warning" />)
-    expect(screen.getByRole("img")).toBeInTheDocument();
-    expect(screen.getByRole("img")).toHaveAttribute("alt", "warning");
+    expect(screen.getByRole("img")).toBeInTheDocument()
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "warning")
   })
-  
+
   test("renders as a link when a href prop is passed", async () => {
-    render(<SideNavigationItem href="#"/>);
-    expect(screen.getByRole("link")).toBeInTheDocument();
-    expect(screen.getByRole("link")).toHaveClass("juno-sidenavigation-item");
+    render(<SideNavigationItem href="#" />)
+    expect(screen.getByRole("link")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveClass("juno-sidenavigation-item")
   })
-  
+
   test("renders as a button when an onClick prop is passed", async () => {
-    render(<SideNavigationItem onClick={()=>{console.log("click")}} />);
-    expect(screen.getByRole("button")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveClass("juno-sidenavigation-item");
+    render(
+      <SideNavigationItem
+        onClick={() => {
+          console.log("click")
+        }}
+      />
+    )
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass("juno-sidenavigation-item")
   })
-  
-  test('renders an active ToppNavigationItem as passed', async () => {
-    render(<SideNavigationItem data-testid="side-nav-item" active />);
-    expect(screen.getByRole("button")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveClass("juno-sidenavigation-item");
-    expect(screen.getByRole("button")).toHaveClass("juno-sidenavigation-item-active");
-    expect(screen.getByRole("button")).toHaveAttribute("aria-selected", "true");
-  });
-  
-  test('renders an aria-label as passed', async () => {
-    render(<SideNavigationItem  href="#" ariaLabel="hey nav item!" />);
-    expect(screen.getByRole('link')).toHaveAttribute('aria-label', 'hey nav item!');
-  });
-  
+
+  test("renders an active ToppNavigationItem as passed", async () => {
+    render(<SideNavigationItem data-testid="side-nav-item" active />)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass("juno-sidenavigation-item")
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    expect(screen.getByRole("button")).toHaveAttribute("aria-selected", "true")
+  })
+
+  test("rerenders the active attribute of the ToppNavigationItem", async () => {
+    const { rerender } = render(
+      <SideNavigationItem data-testid="side-nav-item" active={true} />
+    )
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+    rerender(<SideNavigationItem data-testid="side-nav-item" active={false} />)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).not.toHaveClass(
+      "juno-sidenavigation-item-active"
+    )
+  })
+
+  test("renders an aria-label as passed", async () => {
+    render(<SideNavigationItem href="#" ariaLabel="hey nav item!" />)
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "aria-label",
+      "hey nav item!"
+    )
+  })
+
   test("executes an onClick handler as passed", async () => {
     render(
       <SideNavigation>
-        <SideNavigationItem onClick={mockOnClick} label="My Item"/>
-      </SideNavigation>)
-    expect(screen.getByRole("button", {name: "My Item"})).toBeInTheDocument()
-    await userEvent.click(screen.getByRole("button", {name: "My Item"}))
+        <SideNavigationItem onClick={mockOnClick} label="My Item" />
+      </SideNavigation>
+    )
+    expect(screen.getByRole("button", { name: "My Item" })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "My Item" }))
     expect(mockOnClick).toHaveBeenCalled()
   })
 
-  test('renders custom classNames as passed', async () => {
-    render(<SideNavigationItem  data-testid="side-nav-item" className='my-custom-class' />);
-    expect(screen.getByTestId('side-nav-item')).toHaveClass('my-custom-class');
-  });
+  test("renders custom classNames as passed", async () => {
+    render(
+      <SideNavigationItem
+        data-testid="side-nav-item"
+        className="my-custom-class"
+      />
+    )
+    expect(screen.getByTestId("side-nav-item")).toHaveClass("my-custom-class")
+  })
 
-  test('renders all props as passed', async () => {
-    render(<SideNavigationItem  data-testid="side-nav-item" data-lol='Prop goes here' />);
-    expect(screen.getByTestId('side-nav-item')).toHaveAttribute('data-lol', 'Prop goes here');
-  });
-  
-});
+  test("renders all props as passed", async () => {
+    render(
+      <SideNavigationItem
+        data-testid="side-nav-item"
+        data-lol="Prop goes here"
+      />
+    )
+    expect(screen.getByTestId("side-nav-item")).toHaveAttribute(
+      "data-lol",
+      "Prop goes here"
+    )
+  })
+})

--- a/libs/juno-ui-components/src/components/TabNavigation/TabNavigation.test.js
+++ b/libs/juno-ui-components/src/components/TabNavigation/TabNavigation.test.js
@@ -7,143 +7,259 @@ import { TabNavigationItem } from "../TabNavigationItem/index"
 const mockOnActiveItemChange = jest.fn()
 
 describe("TabNavigation", () => {
-  
   afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
+    cleanup()
+    jest.clearAllMocks()
   })
-  
+
   test("renders a TabNavigation", async () => {
     render(<TabNavigation />)
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.getByRole("navigation")).toHaveClass("juno-tabnavigation")
   })
-  
+
   test("renders children as passed", async () => {
     render(
       <TabNavigation>
         <TabNavigationItem>Item 1</TabNavigationItem>
         <TabNavigationItem>Item 2</TabNavigationItem>
         <TabNavigationItem>Item 3</TabNavigationItem>
-      </TabNavigation>)
-      expect(screen.getByRole("navigation")).toBeInTheDocument()
-      expect(screen.queryAllByRole("button")).toHaveLength(3)
-      expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 3"})).toBeInTheDocument()
+      </TabNavigation>
+    )
+    expect(screen.getByRole("navigation")).toBeInTheDocument()
+    expect(screen.queryAllByRole("button")).toHaveLength(3)
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 3" })).toBeInTheDocument()
   })
-  
+
   test("renders an aria-label as passed", async () => {
     render(<TabNavigation ariaLabel="the relelvance of the navigation" />)
     expect(screen.getByRole("navigation")).toBeInTheDocument()
-    expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "the relelvance of the navigation")
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "aria-label",
+      "the relelvance of the navigation"
+    )
   })
-  
+
   test("renders disabled children as passed", async () => {
     render(
       <TabNavigation disabled>
         <TabNavigationItem label="Item 1" />
         <TabNavigationItem label="Item 2" />
-      </TabNavigation>)
-      expect(screen.getByRole("navigation")).toBeInTheDocument()
-      expect(screen.queryAllByRole("button")).toHaveLength(2)
-      expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 1"})).toBeDisabled()
-      expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-disabled", "true")
-      expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-      expect(screen.getByRole("button", {name: "Item 2"})).toBeDisabled()
-      expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-disabled", "true")
+      </TabNavigation>
+    )
+    expect(screen.getByRole("navigation")).toBeInTheDocument()
+    expect(screen.queryAllByRole("button")).toHaveLength(2)
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
-  
+
   test("renders an active tab as passed by label", async () => {
-    render(<TabNavigation activeItem="Item 2">
-      <TabNavigationItem label="Item 1" />
-      <TabNavigationItem label="Item 2" />
-    </TabNavigation>)
+    render(
+      <TabNavigation activeItem="Item 2">
+        <TabNavigationItem label="Item 1" />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 1"})).not.toHaveClass("juno-tabnavigation-item-active")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveClass("juno-tabnavigation-item-active")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
   })
-  
+
   test("renders an active tab as passed by value", async () => {
-    render(<TabNavigation activeItem="item-2">
-      <TabNavigationItem value="item-1" label="Item 1" />
-      <TabNavigationItem value="item-2" label="Item 2" />
-    </TabNavigation>)
+    render(
+      <TabNavigation activeItem="item-2">
+        <TabNavigationItem value="item-1" label="Item 1" />
+        <TabNavigationItem value="item-2" label="Item 2" />
+      </TabNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 1"})).not.toHaveClass("juno-tabnavigation-item-active")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveClass("juno-tabnavigation-item-active")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
   })
-  
+
   test("renders the active tab as passed to the parent if conflicting with active prop passed to child item", async () => {
-    render(<TabNavigation activeItem="Item 2">
-      <TabNavigationItem label="Item 1" active/>
-      <TabNavigationItem label="Item 2" />
-    </TabNavigation>)
+    render(
+      <TabNavigation activeItem="Item 2">
+        <TabNavigationItem label="Item 1" active />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveAttribute("aria-selected", "false")
-    expect(screen.getByRole("button", {name: "Item 2"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 2"})).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
   })
-  
+
+  test("rerenders the active item as passed to the parent if conflicting with new state of active prop passed to child item", async () => {
+    const { rerender } = render(
+      <TabNavigation activeItem="Item 2">
+        <TabNavigationItem label="Item 1" active />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
+
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    rerender(
+      <TabNavigation activeItem="Item 1">
+        <TabNavigationItem label="Item 1" />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+  })
+
+  test("rerenders the active item as passed to the parent if conflicting with new state of active prop passed to child item", async () => {
+    const { rerender } = render(
+      <TabNavigation activeItem="Item 2">
+        <TabNavigationItem label="Item 1" active />
+        <TabNavigationItem label="Item 2" />
+        <TabNavigationItem label="Item 3" />
+      </TabNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 3" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    rerender(
+      <TabNavigation activeItem="Item 2">
+        <TabNavigationItem label="Item 1" />
+        <TabNavigationItem label="Item 2" />
+        <TabNavigationItem label="Item 3" active />
+      </TabNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 2" })).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    expect(screen.getByRole("button", { name: "Item 3" })).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+  })
+
   test("changes the active tab when the user clicks", async () => {
-    render(<TabNavigation activeItem="Item 1">
-      <TabNavigationItem label="Item 1" />
-      <TabNavigationItem label="Item 2" />
-    </TabNavigation>)
+    render(
+      <TabNavigation activeItem="Item 1">
+        <TabNavigationItem label="Item 1" />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    const tab1 = screen.getByRole("button", {name: "Item 1"})
-    const tab2 = screen.getByRole("button", {name: "Item 2"})
+    const tab1 = screen.getByRole("button", { name: "Item 1" })
+    const tab2 = screen.getByRole("button", { name: "Item 2" })
     expect(tab1).toHaveAttribute("aria-selected", "true")
     expect(tab2).toHaveAttribute("aria-selected", "false")
     await userEvent.click(tab2)
     expect(tab1).toHaveAttribute("aria-selected", "false")
     expect(tab2).toHaveAttribute("aria-selected", "true")
   })
-  
+
   test("executes a handler as passed when the selected tab changes", async () => {
-    render(<TabNavigation activeItem="Item 1" onActiveItemChange={mockOnActiveItemChange}>
-      <TabNavigationItem label="Item 1" />
-      <TabNavigationItem label="Item 2" />
-    </TabNavigation>)
+    render(
+      <TabNavigation
+        activeItem="Item 1"
+        onActiveItemChange={mockOnActiveItemChange}
+      >
+        <TabNavigationItem label="Item 1" />
+        <TabNavigationItem label="Item 2" />
+      </TabNavigation>
+    )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
     expect(screen.queryAllByRole("button")).toHaveLength(2)
-    const tab2 = screen.getByRole("button", {name: "Item 2"})
+    const tab2 = screen.getByRole("button", { name: "Item 2" })
     await userEvent.click(tab2)
     expect(mockOnActiveItemChange).toHaveBeenCalled()
   })
-  
+
   test("renders a main style tab navigation by default", async () => {
     render(
       <TabNavigation>
-        <TabNavigationItem label="Item 1"/>
+        <TabNavigationItem label="Item 1" />
       </TabNavigation>
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
-    expect(screen.getByRole("navigation")).toHaveClass("juno-tabnavigation-main")
+    expect(screen.getByRole("navigation")).toHaveClass(
+      "juno-tabnavigation-main"
+    )
   })
-  
+
   test("renders a content style tab navigation by passed", async () => {
     render(
       <TabNavigation tabStyle="content">
-        <TabNavigationItem label="Item 1"/>
+        <TabNavigationItem label="Item 1" />
       </TabNavigation>
     )
     expect(screen.getByRole("navigation")).toBeInTheDocument()
-    expect(screen.getByRole("navigation")).toHaveClass("juno-tabnavigation-content")
+    expect(screen.getByRole("navigation")).toHaveClass(
+      "juno-tabnavigation-content"
+    )
   })
 
   test("renders a custom classNames", async () => {

--- a/libs/juno-ui-components/src/components/TabNavigationItem/TabNavigationItem.component.js
+++ b/libs/juno-ui-components/src/components/TabNavigationItem/TabNavigationItem.component.js
@@ -51,7 +51,6 @@ export const TabNavigationItem = ({
   value,
   ...props
 }) => {
-  
   const navigationContext = useContext(NavigationContext)
   const {
     activeItem: activeItem,
@@ -60,34 +59,27 @@ export const TabNavigationItem = ({
     disabled: groupDisabled,
     tabStyle: tabStyle,
   } = navigationContext || {}
-  
+
   // Use the value (if passed) or the label as identifying key or the tab:
   const theKey = value || label
-  
+
   // Lazily init depending on parent context or tab's own prop:
   const initialActive = () => {
-    if (navigationContext) {
-      activeItem === theKey ? true : false
+    if (navigationContext?.activeItem?.length > 0) {
+      return activeItem === theKey
     } else {
       return active
     }
   }
-  
-  const [ isActive, setIsActive] = useState( () => initialActive() )
-  
-  // Set the parent state once if not set on the parent, but a tab navigation item has been set to active via its own prop:
-  useEffect(() => {
-    if (active && navigationContext && !activeItem) {
-      updateActiveItem(theKey)
-    }
-  }, [])
-  
+
+  const [isActive, setIsActive] = useState(() => initialActive())
+
   useEffect(() => {
     if (activeItem) {
       activeItem === theKey ? setIsActive(true) : setIsActive(false)
-    } else {
-      setIsActive(active)
+      return
     }
+    setIsActive(active)
   }, [activeItem, active])
 
   const handleItemClick = (event) => {
@@ -96,55 +88,74 @@ export const TabNavigationItem = ({
     }
     onClick && onClick(event)
   }
-  
+
   return (
     <li className={`jn-flex`}>
-    
-    { href ? 
-        <a 
+      {href ? (
+        <a
           className={`
             juno-tabnavigation-item
             juno-tabnavigation-item-${tabStyle}
-            ${ itemStyles } 
-            ${ disabled || groupDisabled ? disabledItemStyles : "" }
-            ${ disabled || groupDisabled ? "juno-tabnavigation-item-disabled" : ""}
-            ${ isActive ? activeItemStyles : ( tabStyle === "content" ? defaultContentItemStyles : defaultMainItemStyles) }
-            ${ isActive ? "juno-tabnavigation-item-active" : "" }
-            ${ className }
+            ${itemStyles} 
+            ${disabled || groupDisabled ? disabledItemStyles : ""}
+            ${
+              disabled || groupDisabled
+                ? "juno-tabnavigation-item-disabled"
+                : ""
+            }
+            ${
+              isActive
+                ? activeItemStyles
+                : tabStyle === "content"
+                ? defaultContentItemStyles
+                : defaultMainItemStyles
+            }
+            ${isActive ? "juno-tabnavigation-item-active" : ""}
+            ${className}
           `}
           onClick={handleItemClick}
-          href={ href }
+          href={href}
           aria-label={ariaLabel}
           aria-selected={isActive}
-          aria-disabled={ disabled || groupDisabled ? true : false}
+          aria-disabled={disabled || groupDisabled ? true : false}
           {...props}
         >
-          { icon ? <Icon icon={icon} size="18" className={"jn-mr-2"} /> : null }
-          <span>{ children || label || theKey }</span>
+          {icon ? <Icon icon={icon} size="18" className={"jn-mr-2"} /> : null}
+          <span>{children || label || theKey}</span>
         </a>
-      :
-        <button className={`
+      ) : (
+        <button
+          className={`
             juno-tabnavigation-item
             juno-tabnavigation-item-${tabStyle}
-            ${ itemStyles } 
-            ${ disabled || groupDisabled ? disabledItemStyles : ""}
-            ${ disabled || groupDisabled ? "juno-tabnavigation-item-disabled" : ""}
-            ${ isActive ? activeItemStyles : ( tabStyle === "content" ? defaultContentItemStyles : defaultMainItemStyles) }
-            ${ isActive ? "juno-tabnavigation-item-active" : "" }
-            ${ className } 
+            ${itemStyles} 
+            ${disabled || groupDisabled ? disabledItemStyles : ""}
+            ${
+              disabled || groupDisabled
+                ? "juno-tabnavigation-item-disabled"
+                : ""
+            }
+            ${
+              isActive
+                ? activeItemStyles
+                : tabStyle === "content"
+                ? defaultContentItemStyles
+                : defaultMainItemStyles
+            }
+            ${isActive ? "juno-tabnavigation-item-active" : ""}
+            ${className} 
           `}
           onClick={handleItemClick}
           aria-label={ariaLabel}
           aria-selected={isActive}
-          disabled={disabled || groupDisabled ? true : false }
-          aria-disabled={ disabled || groupDisabled ? true : false}
+          disabled={disabled || groupDisabled ? true : false}
+          aria-disabled={disabled || groupDisabled ? true : false}
           {...props}
         >
-          { icon ? <Icon icon={icon} size="18" className={"jn-mr-2"} /> : null }
-          <span>{ children || label || theKey }</span>
+          {icon ? <Icon icon={icon} size="18" className={"jn-mr-2"} /> : null}
+          <span>{children || label || theKey}</span>
         </button>
-    }
-      
+      )}
     </li>
   )
 }
@@ -168,7 +179,7 @@ TabNavigationItem.propTypes = {
   label: PropTypes.string,
   /** Pass a custom handler to execute when the tab is clicked */
   onClick: PropTypes.func,
-  /** An optional technical identifier fort the tab. If not passed, the label will be used to identify the tab. NOTE: If value is passed, the value of the active tab MUST be used when setting the activeItem prop on the parent TabNavigation.*/ 
+  /** An optional technical identifier fort the tab. If not passed, the label will be used to identify the tab. NOTE: If value is passed, the value of the active tab MUST be used when setting the activeItem prop on the parent TabNavigation.*/
   value: PropTypes.string,
 }
 

--- a/libs/juno-ui-components/src/components/TabNavigationItem/TabNavigationItem.test.js
+++ b/libs/juno-ui-components/src/components/TabNavigationItem/TabNavigationItem.test.js
@@ -7,101 +7,141 @@ import { TabNavigation } from "../TabNavigation/index"
 const mockOnClick = jest.fn()
 
 describe("TabNavigationItem", () => {
-  
   afterEach(() => {
-    cleanup();
-    jest.clearAllMocks();
+    cleanup()
+    jest.clearAllMocks()
   })
-  
+
   test("renders a TabNavigationItem", async () => {
     render(<TabNavigationItem data-testid={"tab-nav-item"} />)
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
-    expect(screen.getByTestId("tab-nav-item")).toHaveClass("juno-tabnavigation-item")
+    expect(screen.getByTestId("tab-nav-item")).toHaveClass(
+      "juno-tabnavigation-item"
+    )
   })
-  
+
   test("renders a label as passed", async () => {
     render(<TabNavigationItem data-testid={"tab-nav-item"} label="Item" />)
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
     expect(screen.getByTestId("tab-nav-item")).toHaveTextContent("Item")
   })
-  
+
   test("renders children as passed", async () => {
     render(<TabNavigationItem>The Item Is A Child</TabNavigationItem>)
     expect(screen.getByRole("button")).toBeInTheDocument()
     expect(screen.getByRole("button")).toHaveTextContent("The Item Is A Child")
   })
-  
+
   test("renders an aria-label as passed", async () => {
     render(<TabNavigationItem ariaLabel="My ARIA-Label" />)
     expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "My ARIA-Label")
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "My ARIA-Label"
+    )
   })
-  
+
   test("renders a disabled tab navigation item as passed", async () => {
     render(<TabNavigationItem data-testid={"tab-nav-item"} disabled />)
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
     expect(screen.getByTestId("tab-nav-item")).toBeDisabled()
-    expect(screen.getByTestId("tab-nav-item")).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByTestId("tab-nav-item")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
-  
+
   test("renders an icon as passed", async () => {
     render(<TabNavigationItem icon="warning" />)
     expect(screen.getByRole("img")).toBeInTheDocument()
     expect(screen.getByRole("img")).toHaveAttribute("alt", "warning")
   })
-  
+
   test("renders as a link when a href prop is passed", async () => {
-    render(<TabNavigationItem href="#"/>)
-    expect(screen.getByRole("link")).toBeInTheDocument();
-    expect(screen.getByRole("link")).toHaveClass("juno-tabnavigation-item");
+    render(<TabNavigationItem href="#" />)
+    expect(screen.getByRole("link")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveClass("juno-tabnavigation-item")
   })
-  
+
   test("renders an active navigation item as passed", async () => {
     render(<TabNavigationItem active />)
     expect(screen.getByRole("button")).toBeInTheDocument()
     expect(screen.getByRole("button")).toHaveClass("juno-tabnavigation-item")
-    expect(screen.getByRole("button")).toHaveClass("juno-tabnavigation-item-active")
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
     expect(screen.getByRole("button")).toHaveAttribute("aria-selected", "true")
   })
-  
+
+  test("rerenders the active attribute of the TabNavigationItem", async () => {
+    const { rerender } = render(
+      <TabNavigationItem data-testid="tab-nav-item" active={true} />
+    )
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+    rerender(<TabNavigationItem data-testid="tab-nav-item" active={false} />)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).not.toHaveClass(
+      "juno-tabnavigation-item-active"
+    )
+  })
+
   test("executes an onClick handler as passed", async () => {
     render(
       <TabNavigation>
         <TabNavigationItem data-testid={"tab-nav-item"} onClick={mockOnClick} />
-      </TabNavigation>)
+      </TabNavigation>
+    )
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
     await userEvent.click(screen.getByTestId("tab-nav-item"))
     expect(mockOnClick).toHaveBeenCalled()
   })
-  
-  test("renders main style tab navigation items by default inside a TabNavigation", async() => {
+
+  test("renders main style tab navigation items by default inside a TabNavigation", async () => {
     render(
-    <TabNavigation>
-      <TabNavigationItem label="Item 1" />
-    </TabNavigation>)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveClass("juno-tabnavigation-item-main")
+      <TabNavigation>
+        <TabNavigationItem label="Item 1" />
+      </TabNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveClass(
+      "juno-tabnavigation-item-main"
+    )
   })
-  
-  test("renders content style tab navigation items as passed to the parent TabNavigation", async() => {
+
+  test("renders content style tab navigation items as passed to the parent TabNavigation", async () => {
     render(
-    <TabNavigation tabStyle="content">
-      <TabNavigationItem label="Item 1" />
-    </TabNavigation>)
-    expect(screen.getByRole("button", {name: "Item 1"})).toBeInTheDocument()
-    expect(screen.getByRole("button", {name: "Item 1"})).toHaveClass("juno-tabnavigation-item-content")
+      <TabNavigation tabStyle="content">
+        <TabNavigationItem label="Item 1" />
+      </TabNavigation>
+    )
+    expect(screen.getByRole("button", { name: "Item 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Item 1" })).toHaveClass(
+      "juno-tabnavigation-item-content"
+    )
   })
-  
+
   test("renders a className as passed", async () => {
-    render(<TabNavigationItem data-testid={"tab-nav-item"} className="my-custom-class" />)
+    render(
+      <TabNavigationItem
+        data-testid={"tab-nav-item"}
+        className="my-custom-class"
+      />
+    )
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
     expect(screen.getByTestId("tab-nav-item")).toHaveClass("my-custom-class")
   })
-  
+
   test("renders all props as passed", async () => {
-    render(<TabNavigationItem data-testid={"tab-nav-item"} data-lol="lol-1-2-3" />)
+    render(
+      <TabNavigationItem data-testid={"tab-nav-item"} data-lol="lol-1-2-3" />
+    )
     expect(screen.getByTestId("tab-nav-item")).toBeInTheDocument()
-    expect(screen.getByTestId("tab-nav-item")).toHaveAttribute("data-lol", "lol-1-2-3")
+    expect(screen.getByTestId("tab-nav-item")).toHaveAttribute(
+      "data-lol",
+      "lol-1-2-3"
+    )
   })
-  
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -857,7 +857,6 @@
         "@svgr/core": "^7.0.0",
         "@svgr/plugin-jsx": "^7.0.0",
         "@swc/wasm-web": "^1.3.107",
-        "@tanstack/react-query": "4.28.0",
         "@testing-library/dom": "^8.19.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -884,7 +883,6 @@
         "zustand": "4.3.7"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "4.28.0",
         "juno-ui-components": "*",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
@@ -2024,7 +2022,7 @@
       }
     },
     "libs/juno-ui-components": {
-      "version": "2.11.1",
+      "version": "2.11.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-transform-parameters": "^7.22.5",


### PR DESCRIPTION
- [x]  SideNavigationItem  tested successfully with Greenhouse-mng using active attribute
- [x] TabNavigationItem tested successfully with heureka using active attribute