### PR TITLE
[ui] DateTimePicker: add correct dateFormat to story

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
@@ -654,7 +654,7 @@ DateTimePicker.defaultProps = {
   locale: null,
   maxDate: null,
   minDate: null,
-  minuteIncrement: 5,
+  minuteIncrement: 1,
   mode: "single",
   monthSelectorType: "static",
   name: "",

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
@@ -212,6 +212,26 @@ export const DateTimePicker = ({
     onClear && onClear([], "")
   }
 
+  // Function to determine the date format. Will return the dateFormat if passed as a prop, or a useful defaultFormat depending on whether the DateTimePicker is set to show the time, seconds, or no calendar at all (time picker only).
+  const getDateFormat = () => {
+    const defaultDateFormat = enableTime
+      ? noCalendar
+        ? enableSeconds
+          ? "H:i:S"
+          : "H:i"
+        : enableSeconds
+        ? "Y-m-d H:i:S"
+        : "Y-m-d H:i"
+      : "Y-m-d"
+
+    const theDateFormat =
+      dateFormat === undefined ? defaultDateFormat : dateFormat
+
+    return theDateFormat
+  }
+
+  const theDateFormat = getDateFormat()
+
   const createFlatpickrInstance = () => {
     const options = {
       allowInput: allowInput,
@@ -219,7 +239,7 @@ export const DateTimePicker = ({
       ariaDateFormat: ariaDateFormat,
       appendTo: calendarTargetRef.current,
       conjunction: conjunction,
-      dateFormat: dateFormat,
+      dateFormat: theDateFormat,
       defaultDate: defaultDate || defaultValue,
       defaultHour: defaultHour,
       defaultMinute: defaultMinute,
@@ -366,7 +386,8 @@ export const DateTimePicker = ({
   }, [conjunction])
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("dateFormat", dateFormat)
+    const newDateFormat = getDateFormat()
+    flatpickrInstanceRef.current?.set("dateFormat", newDateFormat)
   }, [dateFormat])
 
   useEffect(() => {
@@ -544,13 +565,13 @@ DateTimePicker.propTypes = {
   className: PropTypes.string,
   /** A custom string to separate individual dates in `multiple` mode. */
   conjunction: PropTypes.string,
-  /** A string of characters to define how a date will be formatted in the input field. Available options: https://flatpickr.js.org/formatting/ */
+  /** A string of characters to customize how a date will be formatted in the input field. Available options: https://flatpickr.js.org/formatting/ */
   dateFormat: PropTypes.string,
   /** Sets the default date of the DateTimePicker. Same as `value`, only here for compatibility with the original Flatpickr library. If both `value` and `defaultDate` are being passed, `value` will win. Date Objects, timestamps, ISO date strings, chronological date strings `YYYY-MM-DD HH:MM` (must be compatible to current `dateFormat`), and the shortcut `today` are all accepted. */
   defaultDate: datePropType,
-  /** The initial value of the hour input element. Only effective if time is enabled. */
+  /** The initial value of the hour input element. Only effective if time is enabled. Note this will only set the hour input element to the value specified. Setting this options will not set a selected value on the DateTimePicker. */
   defaultHour: PropTypes.number,
-  /** The initial value of the minute input element. Only effective if time is enabled. */
+  /** The initial value of the minute input element. Only effective if time is enabled. Note this will only set the minute input element to the value specified. Setting this options will not set a selected value on the DateTimePicker. */
   defaultMinute: PropTypes.number,
   /** Same as value, defaultDate */
   defaultValue: datePropType,
@@ -636,7 +657,7 @@ DateTimePicker.defaultProps = {
   ariaDateFormat: "F j, Y",
   className: "",
   conjunction: ", ",
-  dateFormat: "Y-m-d",
+  dateFormat: undefined,
   defaultHour: 12,
   defaultMinute: 0,
   defaultDate: null,

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
@@ -239,6 +239,7 @@ export const With24hTime = Template.bind({})
 With24hTime.args = {
   enableTime: true,
   time_24hr: true,
+  dateFormat: "Y-m-d H:i",
 }
 
 export const ShowTwoMonths = Template.bind({})

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
@@ -104,11 +104,12 @@ WithDefaultHourAndMinute.parameters = {
     },
   },
 }
-WithDefaultDateAndTime.args = {
+WithDefaultHourAndMinute.args = {
   defaultHour: 9,
   defaultMinute: 13,
   enableTime: true,
-  dateFormat: "Y-m-d H:i",
+  helptext:
+    "The hour and minute input elements in the dropdown calendar have been set to default values (09:13 AM).",
 }
 
 export const WithDefaultValue = Template.bind({})
@@ -129,7 +130,7 @@ WithValueAsDateString.parameters = {
   docs: {
     description: {
       story:
-        'Pass a string as a `value`, `defaultValue`, or `defaultDate` that is compatible with the current `dateFormat` prop, e.g. `"2024-01-24"` if the current `dateFormat` is `"Y-m-d"` (as is the default). The Datepicker component will not convert these.',
+        'Pass a string as a `value`, `defaultValue`, or `defaultDate` that is compatible with the current `dateFormat` prop, e.g. `"2024-01-24"` if the current `dateFormat` is `"Y-m-d"` (as is the default). The DateTimePicker component will not convert these.',
     },
   },
 }
@@ -176,6 +177,13 @@ WithValueAsTodayShortcut.args = {
   value: "today",
 }
 
+export const WithCustomDateFormat = Template.bind()
+WithCustomDateFormat.parameters = {}
+WithCustomDateFormat.args = {
+  value: "today",
+  dateFormat: "F d, Y",
+}
+
 export const WithTime = Template.bind({})
 WithTime.parameters = {
   docs: {
@@ -187,7 +195,6 @@ WithTime.parameters = {
 }
 WithTime.args = {
   enableTime: true,
-  dateFormat: "Y-m-d H:i",
 }
 
 export const WithTimeAndSeconds = Template.bind({})
@@ -202,7 +209,6 @@ WithTimeAndSeconds.parameters = {
 WithTimeAndSeconds.args = {
   enableTime: true,
   enableSeconds: true,
-  dateFormat: "Y-m-d H:i:S",
 }
 
 export const WithTimeWithCustomHourIncrement = Template.bind({})
@@ -217,7 +223,7 @@ WithTimeWithCustomHourIncrement.parameters = {
 WithTimeWithCustomHourIncrement.args = {
   enableTime: true,
   hourIncrement: 6,
-  dateFormat: "Y-m-d H:i",
+  helptext: "The hour input of this DateTimePicker has a 6 hour increment.",
 }
 
 export const WithTimeWithCustomMinuteIncrement = Template.bind({})
@@ -231,15 +237,22 @@ WithTimeWithCustomMinuteIncrement.parameters = {
 }
 WithTimeWithCustomMinuteIncrement.args = {
   enableTime: true,
-  minuteIncrement: 1,
-  dateFormat: "Y-m-d H:i",
+  minuteIncrement: 5,
+  helptext: "The minute input of this DateTimePicker has a 5 minute increment.",
 }
 
 export const With24hTime = Template.bind({})
+With24hTime.parameters = {
+  docs: {
+    description: {
+      story:
+        "Set the time picker to use 24h time mode without AM/PM selection.",
+    },
+  },
+}
 With24hTime.args = {
   enableTime: true,
   time_24hr: true,
-  dateFormat: "Y-m-d H:i",
 }
 
 export const ShowTwoMonths = Template.bind({})
@@ -345,7 +358,6 @@ TimePicker.args = {
   enableTime: true,
   noCalendar: true,
   enableSeconds: true,
-  dateFormat: "H:i:S",
 }
 
 export const WithMinDate = Template.bind({})

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
@@ -95,12 +95,12 @@ WithDefaultDate.args = {
   defaultDate: new Date(),
 }
 
-export const WithDefaultDateAndTime = Template.bind({})
-WithDefaultDateAndTime.parameters = {
+export const WithDefaultHourAndMinute = Template.bind({})
+WithDefaultHourAndMinute.parameters = {
   docs: {
     description: {
       story:
-        "Pass `defaultHour` and `defaultMinute` to set default values for the date and time input elements. Note this will not set a selected date with these values in the DateTimePicker input element, the user still has to make a selection.",
+        "Pass `defaultHour` and `defaultMinute` to set default values for the date and time input elements. Note: this will not set a selected date with these values in the DateTimePicker input element, the user still has to make a selection.",
     },
   },
 }
@@ -247,7 +247,7 @@ ShowTwoMonths.parameters = {
   docs: {
     description: {
       story:
-        "Setr the number of months to be displayed side by side in the calendar.",
+        "Set the number of months to be displayed side by side in the calendar.",
     },
   },
 }

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
@@ -182,13 +182,7 @@ describe("DateTimePicker", () => {
   })
 
   test("renders a DateTimePicker with a time picker with seconds as passed", async () => {
-    render(
-      <DateTimePicker
-        enableTime={true}
-        enableSeconds={true}
-        dateFormat="Y-m-d H:i:S"
-      />
-    )
+    render(<DateTimePicker enableTime={true} enableSeconds={true} />)
     expect(screen.getByRole("textbox")).toBeInTheDocument()
     expect(document.querySelector(".flatpickr-time")).toBeInTheDocument()
     expect(screen.getByLabelText("Hour")).toBeInTheDocument()
@@ -236,6 +230,69 @@ describe("DateTimePicker", () => {
     render(<DateTimePicker dateFormat="F d Y" value={1706273787000} />)
     expect(screen.getByRole("textbox")).toBeInTheDocument()
     expect(screen.getByRole("textbox")).toHaveValue("January 26 2024")
+  })
+
+  test("uses the default dateFormat (Y-m-d) in default (non-time picker) mode)", async () => {
+    const today = new Date()
+    const fullYear = today.getFullYear()
+    const month = (today.getMonth() + 1).toString().padStart(2, "0")
+    const day = today.getDate().toString().padStart(2, "0")
+    const todayAsString = `${fullYear}-${month}-${day}`
+    render(<DateTimePicker value={today} />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toHaveValue(todayAsString)
+  })
+
+  test("uses the correct default dateFormat (Y-m-d H:i) in date-time-picker mode without seconds", async () => {
+    const now = new Date()
+    const fullYear = now.getFullYear()
+    const month = (now.getMonth() + 1).toString().padStart(2, "0")
+    const day = now.getDate().toString().padStart(2, "0")
+    const hours = now.getHours().toString().padStart(2, "0")
+    const minutes = now.getMinutes().toString().padStart(2, "0")
+    const nowAsString = `${fullYear}-${month}-${day} ${hours}:${minutes}`
+    render(<DateTimePicker enableTime value={now} />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toHaveValue(nowAsString)
+  })
+
+  test("uses the correct default dateFormat (Y-m-d H:i:S) in date-time-picker mode with seconds enabled", async () => {
+    const now = new Date()
+    const fullYear = now.getFullYear()
+    const month = (now.getMonth() + 1).toString().padStart(2, "0")
+    const day = now.getDate().toString().padStart(2, "0")
+    const hours = now.getHours().toString().padStart(2, "0")
+    const minutes = now.getMinutes().toString().padStart(2, "0")
+    const seconds = now.getSeconds().toString().padStart(2, "0")
+    const nowAsStringWithSeconds = `${fullYear}-${month}-${day} ${hours}:${minutes}:${seconds}`
+    render(<DateTimePicker enableTime enableSeconds value={now} />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toHaveValue(nowAsStringWithSeconds)
+  })
+
+  test("uses the correct default dateFormat (H:i) in time-picker-only mode without seconds", async () => {
+    const now = new Date()
+    const hours = now.getHours().toString().padStart(2, "0")
+    const minutes = now.getMinutes().toString().padStart(2, "0")
+    const nowAsStringWithOnlyHoursAndMinutes = `${hours}:${minutes}`
+    render(<DateTimePicker enableTime noCalendar value={now} />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toHaveValue(
+      nowAsStringWithOnlyHoursAndMinutes
+    )
+  })
+
+  test("uses the correct defaultDateFormat (H:i:S) in time-picker-only mode with seconds enabled", async () => {
+    const now = new Date()
+    const hours = now.getHours().toString().padStart(2, "0")
+    const minutes = now.getMinutes().toString().padStart(2, "0")
+    const seconds = now.getSeconds().toString().padStart(2, "0")
+    const nowAsStringWithOnlyHoursMinutesAndSeconds = `${hours}:${minutes}:${seconds}`
+    render(<DateTimePicker enableTime enableSeconds noCalendar value={now} />)
+    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    expect(screen.getByRole("textbox")).toHaveValue(
+      nowAsStringWithOnlyHoursMinutesAndSeconds
+    )
   })
 
   test("displays the date as passed as defaultDate instead of value or defaultDate", async () => {


### PR DESCRIPTION
Closes #563. 

**Issue 1 – browser warning re non-conforming value in minute input when `enableTime` is set to true** 
Set the default `minuteIncrement` to 1, thus preventing the first issue descried.

**Issue 2 – onChange handler not firing every time when value (time) changes**
Add heuristic to determine a working default `dateFormat` depending on `enableTime`, `enableSeconds`, and `noCalendar`. As a result, users should never have to set a `dateFormat` themselves in order to have a working component. They are still free to set a custom date format that suits their needs.

**Issue 3 – defaultHour and defaultMinute** 
Rename the story not raise wrong expectations, update/clarify the respective prop and story descriptions.
