### PR TITLE
Unskip AppShellProvider tests

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/AppShellProvider/AppShellProvider.test.js
+++ b/libs/juno-ui-components/src/components/AppShellProvider/AppShellProvider.test.js
@@ -2,17 +2,14 @@ import * as React from "react"
 import { render, screen } from "@testing-library/react"
 import { AppShellProvider } from "./index"
 
-/** Tests need to be adjusted once we know how this will look */
 describe("AppShellProvider", () => {
-  test.skip("renders a AppShellProvider wrapper div with 'theme-dark' theme class by default", async () => {
-    const { container } = render(<AppShellProvider />)
-    expect(container.querySelector("div.juno-app-body")).toHaveClass(
-      "theme-dark"
-    )
+  test("renders an AppShellProvider wrapper div with 'theme-dark' theme class by default", async () => {
+    render(<AppShellProvider shadowRoot={false} />)
+    expect(document.querySelector(".juno-app-body")).toHaveClass("theme-dark")
   })
 
-  test.skip("renders a AppShellProvider wrapper div with theme class as passed", async () => {
-    const { container } = render(<AppShellProvider theme="my-theme" />)
-    expect(container.querySelector("div.juno-app-body")).toHaveClass("my-theme")
+  test("renders an AppShellProvider wrapper div with theme class as passed", async () => {
+    render(<AppShellProvider shadowRoot={false} theme="my-theme" />)
+    expect(document.querySelector("div.juno-app-body")).toHaveClass("my-theme")
   })
 })


### PR DESCRIPTION
Tests were not running and had to be skipped since the div was rendered into a shadowRoot node that need specific attention when testing. Setting shadowRoot to `false` for testing unrelated functionality.