### PR TITLE
feat(gh): rename crds

### DIFF
--- a/apps/greenhouse/package.json
+++ b/apps/greenhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenhouse",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "managementVersion": "1.1.8",
   "author": "UI-Team",
   "contributors": [

--- a/apps/greenhouse/src/hooks/useApi.js
+++ b/apps/greenhouse/src/hooks/useApi.js
@@ -38,7 +38,7 @@ const useApi = () => {
       fetch(manifestUrl).then((r) => r.json()),
       // plugin configs
       client.get(
-        `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/plugin`,
+        `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/plugins`,
         {
           limit: 500,
         }

--- a/apps/greenhouse/src/hooks/useApi.js
+++ b/apps/greenhouse/src/hooks/useApi.js
@@ -38,7 +38,7 @@ const useApi = () => {
       fetch(manifestUrl).then((r) => r.json()),
       // plugin configs
       client.get(
-        `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/pluginconfigs`,
+        `/apis/greenhouse.sap/v1alpha1/namespaces/${namespace}/plugin`,
         {
           limit: 500,
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,7 +297,7 @@
       }
     },
     "apps/greenhouse": {
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.20.2",


### PR DESCRIPTION
This PR fixes the api endpoint to get `Plugins` from (formerly `PluginConfigs`)

**Please do only merge in sync with greenhouse core, this is a breaking change!**

Out of scope:

- Renaming / Refactoring variable and parameter naming. This ONLY fixes the api endpoint.

cc @IvoGoman 