### PR TITLE
DateTimerPicker fix endless loop. Fixes #575, #578

### DIFF
--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -5,7 +5,7 @@
   "module": "build/index.js",
   "source": "src/index.js",
   "style": "build/lib/variables.css",
-  "version": "2.13.6",
+  "version": "2.13.7",
   "files": [
     "src/colors.css",
     "tailwind.config.js"

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
@@ -19,7 +19,10 @@ const inputWrapperStyles = `
 
 const inputStyles = `
   jn-bg-theme-textinput
+  jn-bg-no-repeat
+  jn-bg-[top_0.375rem_right_1rem]
   jn-text-theme-textinput
+  jn-fill-theme-textinput-default
   jn-border
   jn-text-base
   jn-leading-4
@@ -66,8 +69,8 @@ const labelStyles = `
 const iconContainerStyles = `
   jn-absolute
   jn-inline-flex
-  jn-top-1.5
-  jn-right-5
+  jn-top-2
+  jn-right-[2.75rem]
   jn-gap-1.5
 `
 
@@ -200,10 +203,6 @@ export const DateTimePicker = ({
   const handleInputFocus = () => {
     setHasFocus(true)
     onFocus && onFocus(theDate.selectedDate, theDate.selectedDateStr)
-  }
-
-  const handleCalendarIconClick = () => {
-    flatpickrInstanceRef.current?.open()
   }
 
   const handleClearIconClick = () => {
@@ -465,6 +464,11 @@ export const DateTimePicker = ({
             }  
             ${isValid || isInvalid ? "" : inputDefaultBorderStyles} 
             ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+            ${
+              enableTime && noCalendar
+                ? "juno-datetimepicker-input-timepicker"
+                : "juno-datetimepicker-input-default"
+            }
             ${className}
           `}
           data-mode={mode}
@@ -514,11 +518,6 @@ export const DateTimePicker = ({
           ) : (
             ""
           )}
-          <Icon
-            icon={enableTime && noCalendar ? "accessTime" : "calendarToday"}
-            onClick={handleCalendarIconClick}
-            disabled={disabled}
-          />
           {isInvalid ? (
             <Icon icon="dangerous" color="jn-text-theme-error" />
           ) : (

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
@@ -212,6 +212,11 @@ export const DateTimePicker = ({
     onClear && onClear([], "")
   }
 
+  // Create stringified versions of the value prop and its aliases in order to use them in a useEffect dependency array later.
+  const stringifiedValue = JSON.stringify(value)
+  const stringifiedDefaultDate = JSON.stringify(defaultDate)
+  const stringifiedDefaultValue = JSON.stringify(defaultValue)
+
   // Function to determine the date format. Will return the dateFormat if passed as a prop, or a useful defaultFormat depending on whether the DateTimePicker is set to show the time, seconds, or no calendar at all (time picker only).
   const getDateFormat = () => {
     const defaultDateFormat = enableTime
@@ -279,7 +284,6 @@ export const DateTimePicker = ({
 
   useEffect(() => {
     createFlatpickrInstance()
-
     return () => {
       destroyFlatpickrInstance()
     }
@@ -421,12 +425,13 @@ export const DateTimePicker = ({
     flatpickrInstanceRef.current?.set("time_24hr", time_24hr)
   }, [time_24hr])
 
+  // Update the flatpickr instance whenever the value prop (or any of its aliases) changes, and force the flatpickr instance to fire onChange event. These props may contain an array of one or multiple objects. These will never pass React's identity comparison, and will be regarded as a new object with any render regardless of their contents, thus creating an endless loop by updating the flatpickr instance updating the parent state (via onChange above) updating the flatpickr instance (…). We prevent this by checking on the stringified versions of the props in the dependency array.
   useEffect(() => {
     flatpickrInstanceRef.current?.setDate(
       value || defaultDate || defaultValue,
-      true
+      true // enforce firing change event that in turn will update our state via handleChange.
     )
-  }, [value, defaultDate, defaultValue])
+  }, [stringifiedValue, stringifiedDefaultDate, stringifiedDefaultValue])
 
   useEffect(() => {
     flatpickrInstanceRef.current?.set("weekNumbers", weekNumbers)

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import { DateTimePicker } from "./index.js"
 import { PortalProvider } from "../PortalProvider/PortalProvider.component"
+import { Form } from "../Form/"
 
 export default {
   title: "WIP/DateTimePicker/DateTimePicker",
@@ -464,34 +465,31 @@ InvalidPreload.args = {
     "The datpicker initially shows Jan 30, 2024 as value even though this date has been set as disabled and thus can not be selected by a user.",
 }
 
-const TestTemplate = ({ ...args }) => {
+const ControlledTemplate = ({ ...args }) => {
   const [testState, setTestState] = useState({ date: { end: null } })
 
-  console.log("testState", testState)
-
-  const handleDTPickerChange = (dObj, dStr) => {
-    // console.log("dateObject: ", dObj)
-    // console.log("dateStr: ", dStr)
+  const handleChange = (dObj, dStr) => {
     setTestState({ date: { end: dObj } })
   }
 
   return (
     <DateTimePicker
       {...args}
-      onChange={handleDTPickerChange}
+      onChange={handleChange}
       value={testState?.date?.end}
     />
   )
 }
 
-export const FixEndlessLoop = {
-  render: TestTemplate,
-  args: {},
-}
-
-export const FixClearButton = {
-  render: Template,
-  args: {
-    value: "2027-01-12",
+export const ControlledDateTimePicker = {
+  render: ControlledTemplate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Example of controlled usage, using the date object array as returned by the onChange handler in the parent story state. This used to create an endless loop and should be fixed now.",
+      },
+    },
   },
+  args: {},
 }

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.stories.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { DateTimePicker } from "./index.js"
 import { PortalProvider } from "../PortalProvider/PortalProvider.component"
 
@@ -462,4 +462,36 @@ InvalidPreload.args = {
   disable: ["2024-01-30"],
   helptext:
     "The datpicker initially shows Jan 30, 2024 as value even though this date has been set as disabled and thus can not be selected by a user.",
+}
+
+const TestTemplate = ({ ...args }) => {
+  const [testState, setTestState] = useState({ date: { end: null } })
+
+  console.log("testState", testState)
+
+  const handleDTPickerChange = (dObj, dStr) => {
+    // console.log("dateObject: ", dObj)
+    // console.log("dateStr: ", dStr)
+    setTestState({ date: { end: dObj } })
+  }
+
+  return (
+    <DateTimePicker
+      {...args}
+      onChange={handleDTPickerChange}
+      value={testState?.date?.end}
+    />
+  )
+}
+
+export const FixEndlessLoop = {
+  render: TestTemplate,
+  args: {},
+}
+
+export const FixClearButton = {
+  render: Template,
+  args: {
+    value: "2027-01-12",
+  },
 }

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
@@ -24,11 +24,6 @@ describe("DateTimePicker", () => {
     expect(screen.getByRole("textbox")).toHaveClass("juno-datetimepicker-input")
   })
 
-  test("renders a calendar icon", async () => {
-    render(<DateTimePicker />)
-    expect(screen.getByTitle("Calendar")).toBeInTheDocument()
-  })
-
   test("renders a label as passed", async () => {
     render(
       <DateTimePicker label="The DateTimePicker Label" id="my-textinput" />
@@ -600,12 +595,6 @@ describe("DateTimePicker", () => {
     expect(document.querySelector(".flatpickr-days")).not.toBeInTheDocument()
     expect(document.querySelector("input.flatpickr-hour")).toBeInTheDocument()
     expect(document.querySelector("input.flatpickr-minute")).toBeInTheDocument()
-  })
-
-  test("renders a time picker with a clock icon instead of a calendar icon if configured to do so", async () => {
-    render(<DateTimePicker enableTime noCalendar />)
-    expect(screen.getByTitle("Time")).toBeInTheDocument()
-    expect(screen.queryByTitle("Calendar")).not.toBeInTheDocument()
   })
 
   test("executes an onOpen handler when the user clicks the Datepicker and the calendar opens", async () => {

--- a/libs/juno-ui-components/src/components/DateTimePicker/datetimepicker.scss
+++ b/libs/juno-ui-components/src/components/DateTimePicker/datetimepicker.scss
@@ -1,3 +1,21 @@
+.theme-dark {
+  .juno-datetimepicker-input-default {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'24'%20height%3D'24'%20viewBox%3D'0%200%2024%2024'%20fill%3D'rgb(222%2C%20223%2C%20224)'%3E%3Cpath%20d%3D'M20%203h-1V1h-2v2H7V1H5v2H4c-1.1%200-2%20.9-2%202v16c0%201.1.9%202%202%202h16c1.1%200%202-.9%202-2V5c0-1.1-.9-2-2-2zm0%2018H4V8h16v13z'%2F%3E%3C%2Fsvg%3E");
+  }
+  .juno-datetimepicker-input-timepicker {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'24'%20height%3D'24'%20viewBox%3D'0%200%2024%2024'%20fill%3D'rgb(222%2C%20223%2C%20224)'%3E%3Cpath%20d%3D'M11.99%202C6.47%202%202%206.48%202%2012s4.47%2010%209.99%2010C17.52%2022%2022%2017.52%2022%2012S17.52%202%2011.99%202zM12%2020c-4.42%200-8-3.58-8-8s3.58-8%208-8%208%203.58%208%208-3.58%208-8%208z'%2F%3E%3Cpath%20d%3D'M12.5%207H11v6l5.25%203.15.75-1.23-4.5-2.67z'%2F%3E%3C%2Fsvg%3E");
+  }
+}
+
+.theme-light {
+  .juno-datetimepicker-input-default {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'24'%20height%3D'24'%20viewBox%3D'0%200%2024%2024'%20fill%3D'rgb(64%2C%2064%2C%2064)'%3E%3Cpath%20d%3D'M20%203h-1V1h-2v2H7V1H5v2H4c-1.1%200-2%20.9-2%202v16c0%201.1.9%202%202%202h16c1.1%200%202-.9%202-2V5c0-1.1-.9-2-2-2zm0%2018H4V8h16v13z'%2F%3E%3C%2Fsvg%3E");
+  }
+  .juno-datetimepicker-input-timepicker {
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'24'%20height%3D'24'%20viewBox%3D'0%200%2024%2024'%20fill%3D'rgb(64%2C%2064%2C%2064)'%3E%3Cpath%20d%3D'M11.99%202C6.47%202%202%206.48%202%2012s4.47%2010%209.99%2010C17.52%2022%2022%2017.52%2022%2012S17.52%202%2011.99%202zM12%2020c-4.42%200-8-3.58-8-8s3.58-8%208-8%208%203.58%208%208-3.58%208-8%208z'%2F%3E%3Cpath%20d%3D'M12.5%207H11v6l5.25%203.15.75-1.23-4.5-2.67z'%2F%3E%3C%2Fsvg%3E");
+  }
+}
+
 .flatpickr-calendar {
   background: transparent;
   color: var(--color-text-default);


### PR DESCRIPTION
Fix #575
Fix #578 

### Fix endless Loop
Listening to our `value` prop (and its aliases) in a `useEffect` to set the flatpickr instance, and enforcing `onChange` events to update our state on the onChange resulting in our updating the FP instance caused an endless loop. We now JSON.stringify the `value` prop and its aliases and keep these in our dependency array, so they will only be recognized as changed when they _actually have changed_, eventually preventing DateTimePicker from going into an endless loop.

### Fix calendar icon click
The problem was caused by some weird behavior of the `open()` method of the flatpickr instance that we used in `handleCalendarIconClick`. In order to avoid having to use this method, we remove the calendar icon button element completely, and set the calendar icon (or clock icon for pure time pickers) as an inlined background image. By doing this, when users click the icon, they actually click the input element as if they were clicking somewhere else in the DateTimePicker. As a resutl, the `open()` method of flatpickr is not used at all anymore in our component and can not play up. 