### PR TITLE
[ui] Quick fix for storybook build

### DIFF
--- a/libs/juno-ui-components/src/docs/colors.mdx
+++ b/libs/juno-ui-components/src/docs/colors.mdx
@@ -1,7 +1,7 @@
-<!--
-  ~ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
-  ~ SPDX-License-Identifier: Apache-2.0
--->
+/_
+~ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+~ SPDX-License-Identifier: Apache-2.0
+_/
 
 import { Meta, Controls } from "@storybook/blocks"
 import { ColorPalette } from "./ColorPalette/ColorPalette.jsx"

--- a/libs/juno-ui-components/src/docs/navigation.mdx
+++ b/libs/juno-ui-components/src/docs/navigation.mdx
@@ -1,13 +1,13 @@
-<!--
-  ~ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
-  ~ SPDX-License-Identifier: Apache-2.0
--->
+/_
+~ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+~ SPDX-License-Identifier: Apache-2.0
+_/
 
 import { Meta, Controls, Story } from "@storybook/blocks"
 import { LinkTo, hrefTo } from "@storybook/addon-links"
-import { Default as TopNavigationDefaultStory } from "../components/TopNavigation/TopNavigation.stories" 
-import { Default as SideNavigationDefaultStory } from "../components/SideNavigation/SideNavigation.stories" 
-import { Default as TabNavigationDefaultStory } from "../components/TabNavigation/TabNavigation.stories" 
+import { Default as TopNavigationDefaultStory } from "../components/TopNavigation/TopNavigation.stories"
+import { Default as SideNavigationDefaultStory } from "../components/SideNavigation/SideNavigation.stories"
+import { Default as TabNavigationDefaultStory } from "../components/TabNavigation/TabNavigation.stories"
 
 <Meta title="Navigation/Navigation" />
 
@@ -19,10 +19,9 @@ The Juno Design System comes with a variety of navigational elements. They are d
 
 <Story of={TopNavigationDefaultStory} />
 
-A can only be used underneath an application's header, and above any other content elements. When used, it is the primary, top-level navigation. There can only ever be one `TopNavigation` in an application. 
+A can only be used underneath an application's header, and above any other content elements. When used, it is the primary, top-level navigation. There can only ever be one `TopNavigation` in an application.
 
 For applications with a complex navigational or hierarchical structure, a `SideNavigation` and/or `TabNavigation` can be used as a secondary navigation.
-
 
 ## SideNavigation
 
@@ -72,7 +71,6 @@ In order to set an item as the active item, it can be set via an `active` prop o
 
 When both are being passed, the `activeItem` prop on the parent will take precedence.
 
-
 If application logic requires the use of more technical keys to identify any navigational item, it can accept an additional `value` prop:
 
 ```
@@ -114,4 +112,4 @@ You may also pass `children` to each navigation item and they will be rendered. 
 
 ```
 
-When children, values and labels  are being passed to the navigation items, the same caveat will apply as described above: In this case, ONLY the `value` of the respective item will work to set the active item on the parent via `activeItem`.
+When children, values and labels are being passed to the navigation items, the same caveat will apply as described above: In this case, ONLY the `value` of the respective item will work to set the active item on the parent via `activeItem`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2053,7 +2053,7 @@
       }
     },
     "libs/juno-ui-components": {
-      "version": "2.13.6",
+      "version": "2.13.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-transform-parameters": "^7.22.5",


### PR DESCRIPTION
The newly introduced github-action to automatically insert copyright and license information into each file in our project currently uses the wrong comment syntax for .mdx files, causing the storybook build to fail.

Created #590 (https://github.com/sapcc/juno/issues/590) to address fixing this permanently.