### PR TITLE
[storybook] Include Apache licence in autogenerated file.

### DIFF
--- a/apps/supernova/src/components/alerts/Alert.jsx
+++ b/apps/supernova/src/components/alerts/Alert.jsx
@@ -49,7 +49,11 @@ const Alert = ({ alert }, ref) => {
     // then we don't want to show the details because then the click was on a child of one of the cells
     // an additional check is made for targets with className "interactive". If the target has this then the click
     // handling should proceed even if the previous condition was true
-    if ((e.target.parentNode !== rowRef.current) && !e.target.classList.contains("interactive")) return
+    if (
+      e.target.parentNode !== rowRef.current &&
+      !e.target.classList.contains("interactive")
+    )
+      return
 
     e.stopPropagation()
     e.preventDefault()
@@ -77,7 +81,9 @@ const Alert = ({ alert }, ref) => {
       </DataGridCell>
       <DataGridCell>{alert.labels?.service}</DataGridCell>
       <DataGridCell className="cursor-default">
-        <div className="interactive text-theme-high cursor-pointer">{alert.annotations?.summary}</div>
+        <div className="interactive text-theme-high cursor-pointer">
+          {alert.annotations?.summary}
+        </div>
         <div>
           <AlertDescription
             description={alert.annotations?.description}

--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -55,6 +55,7 @@
     "glob": "^8.1.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "js-yaml": "^4.1.0",
     "node-sass-glob-importer": "^3.0.2",
     "postcss": "^8.4.6",
     "postcss-loader": "^6.2.1",

--- a/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/TailwindColors.js
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors 
+ * SPDX-License-Identifier: Apache-2.0 
  */
 
 /* Do not change this File. This is an (by generateTailwindThemeClassesJson.js) auto-generated file for documentation issues.

--- a/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
@@ -5,12 +5,18 @@
 
 const fs = require("fs")
 const tailwindConfig = require("../../../tailwind.config")
+const yaml = require("js-yaml")
+const licenserc = "./licenserc.yaml"
 
 /* 
   Generates Tailwindclasses in a js file. So Tailwind generates the classes and so they are useable in the documentation, which colors are available. 
 */
 
 const generateTailwindThemeClassesJson = () => {
+  const licence = yaml.load(fs.readFileSync(licenserc, "utf8"))
+  const licenceJSON = yaml.safeLoad(licence)
+  console.log(licenceJSON)
+
   fs.writeFileSync(
     "./src/docs/ColorPalette/TailwindColors.js",
     "/*\n" +

--- a/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
+++ b/libs/juno-ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.js
@@ -13,7 +13,11 @@ const tailwindConfig = require("../../../tailwind.config")
 const generateTailwindThemeClassesJson = () => {
   fs.writeFileSync(
     "./src/docs/ColorPalette/TailwindColors.js",
-    "/* Do not change this File. This is an (by generateTailwindThemeClassesJson.js) auto-generated file for documentation issues." +
+    "/*\n" +
+      " * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors \n" +
+      " * SPDX-License-Identifier: Apache-2.0 \n" +
+      " */\n\n" +
+      "/* Do not change this File. This is an (by generateTailwindThemeClassesJson.js) auto-generated file for documentation issues." +
       "\nIt is needed for the ColorPalette and JunoColorPalette to show the documented colors." +
       "\nWe need to do this because Tailwind classes can't be concatenated at runtime via String interpolation. It only works if you use the full class name.*/" +
       "\nexports.getThemeColors = " +

--- a/package-lock.json
+++ b/package-lock.json
@@ -2094,6 +2094,7 @@
         "glob": "^8.1.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
+        "js-yaml": "^4.1.0",
         "node-sass-glob-importer": "^3.0.2",
         "postcss": "^8.4.6",
         "postcss-loader": "^6.2.1",
@@ -2165,11 +2166,29 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "libs/juno-ui-components/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "libs/juno-ui-components/node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
+    },
+    "libs/juno-ui-components/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "libs/messages-provider": {
       "version": "0.1.12",


### PR DESCRIPTION
Extended comment with licence is now generated in the tailwindColors.js file. To avoid losing the license with every build.