### PR TITLE
Add back comment that was removed in #629

### DIFF
--- a/ci/Dockerfile.assets.server
+++ b/ci/Dockerfile.assets.server
@@ -88,7 +88,7 @@ RUN mkdir -p /tmp/final/global && cp /juno/README.md /tmp/final/global/
 
 WORKDIR /tmp/final 
 
-ADD generate_importmap.mjs /juno/ci/scripts/generate_importmap.mjs
+# ADD generate_importmap.mjs /juno/ci/scripts/generate_importmap.mjs
 # delete old importmaps and manifests and obsolete assets (see: ci/obsolete_assets.json
 RUN \
   rm -rf externals_* importmap* importmap* ; \


### PR DESCRIPTION
In #629 a comment was removed that causes the pipeline to fail, because the importmap file cannot be included. This PR adds the comment back.