### PR TITLE
[helm-chart] set service externalTrafficPolicy to Local

### DIFF
--- a/ci/helm-charts/assets_server_ha/templates/service.yaml
+++ b/ci/helm-charts/assets_server_ha/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
   name: assets-server
 
 spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     app: assets-server
   ports:


### PR DESCRIPTION
to advertise the /32 IP to upstream