### PR TITLE
chore(build): run npm build on all packages before building a package

### DIFF
--- a/ci/pipeline.yaml.erb
+++ b/ci/pipeline.yaml.erb
@@ -315,10 +315,11 @@ jobs:
                 WORKDIR=$(pwd)
                 <% if details[:monorepo]%>
                 cd ./latest 
-                npm ci
+                npm install
+                npm run build
                 <% else %>
                 cd ./latest/<%= details[:path] %>
-                npm ci
+                npm install
                 <% end %>
                 cd $WORKDIR/latest
                 echo "Done"


### PR DESCRIPTION
Ensure npm build is executed on all packages before the main build process.

In the pipeline, we handle two different repositories (due to historical reasons). If the packages come from **@cloudoperators/juno**, which is a monorepo, we must first run the build on all dependent packages. This is done using `npm run build`. Only after this step can we proceed with the build task for the current package, ensuring that all dependencies are properly compiled and up-to-date.