### PR TITLE
chore(dashboard): changes the helm charts

### DIFF
--- a/ci/helm-charts/hosting/templates/deployment.yaml
+++ b/ci/helm-charts/hosting/templates/deployment.yaml
@@ -33,8 +33,6 @@ spec:
           ports:
             - name: dashboard
               containerPort: 80
-            - name: exampleapp
-              containerPort: 81  
           resources:
             requests:
               cpu: "100m"

--- a/ci/helm-charts/hosting/templates/index-html-configmap.yaml
+++ b/ci/helm-charts/hosting/templates/index-html-configmap.yaml
@@ -9,31 +9,10 @@ data:
     <html style="margin: 0; padding: 0; display: flex; flex-direction: column;">
     <head>
     <title>CCLOUD</title>
-    <link rel="icon" sizes="any" href="https://assets.juno.global.cloud.sap/assets/favicon.ico"/>
-    <link rel="icon" type="image/png" sizes="16x16"href="https://assets.juno.global.cloud.sap/assets/favicon-16x16.png"/>
-    <link rel="icon" type="image/png" sizes="32x32"href="https://assets.juno.global.cloud.sap/assets/favicon-32x32.png"/>
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAEhklEQVRoBe2aa2xURRTHf+UhhYItWIrgg0qqiagUNCQKHygi2sQIbWOi8QHVCDGpioYPxMQYSGj4YmziB58kqKGhYnglYiCAxigRUaMk8mg1UksLSKkFBKFFuf7PjrvLpdvuttvu7k08ydl778zcmf9/7plzzkwLXWWoip6UbpQ2SS9IvTSpjW0YDMsTUsPWo9yr2p+l6QIcb9wGYSuRxpRKlV6Uxusk3fWdwrhQ6hObeatIN7hExzesJdKQmF1lstl0R8rMKbQmbMF21yjTyx8fJPAV0qBKRZaQN0lvCCiDRiNgvnZYQAl0GAGz88CKrYFAy/8E0v35Av8Fhgz0DE64Bm6Vky7Ig9wRcPovONIKP/4KZ88nP/qAEMjNgcWlMO9uuKMwNsh/LsFX+6H2c9iwG+y5L9KvbnSwDPK5h+ClcsgTibD8qZluaYPWUzByuKLmWMi/OlwLDS2wdDV8+VO0LNG7fiMweiSsXgJzprqhzyk8frATtuyBb5V2Xboi2hSNh/n3wFNz4fp8V//aBli1XoHpirbxyFjzpFSz7e2pwTv1sdO3qvDG5SXWZ/ZQvGUP451Y596tWYyXlZXYu//h7lXjLkSHCcCnK9zgbR/hLSrtW38zJ+MdXuP6WVrRqz561bgLgZcfcYPa7C+Yk1xf02/BO7YWzybizqLE+kpqDRSOA5kOMgPW7NDifTeetcav1yTwxrPQ+Dscaobr5IbNq7WdgePtsPsAbPsOfjnm+kqKwOuL4On7of0sFFfBGfn4ZEX2z9blMGNyzz19tg+q66DPBGT71L/n3OWKWqjZ3POAvamdPUXeqBIMZFOrm6Axo2BigfNyN09wvYW9VRe7VnXcsrnTnO23r8eTG4zbPpE+E21TPAlv4ytu/D5H4tsmulnY/xs0n3T3qfrdpzSkYiU8Ogv6lMxlXyWbv8nBPXAkVbC7jlP3BST0BQpyxXgmPDgdpgi4eYWwnFB6kE7pkcBw7ZSXzIfnld/kZMeGea4jdnmqSrslMH4MrFsGUyc5KJbL7K2PegbLdSxhaz2dKqixx8lSsXkQn1w7GnatckHEKj7ZC8vXRoOHr3EGPBiBiFpus6PauaiTdXjPPBCtu7xdBt37Ab5Y1n+5TYpIRgnIu3iN7zsCbyolThGApMbxxYFybTBsYV64CCuVZwRBfARK73KQt2rRHtUWMAjiIzCtyEHe/n0QoDuMEQJDBsNYRVyT+hZ3DcJvhIBF2kEWFSS2eQiKGIFQMmCbEVu8JqNGuGsAfjuMgDZvimRyZuG0+EYdcwREjhqByJLd+YODPbs4IPCF3QjYX8FDsvlrdy1TPLCNegBkk2G0jPSgNBQRt7zqIrGOCJOKkOH+BvCq3Dj6rwcleui0wW4vdKdkx2vxtHnJVBKGdZbUJwv1FCLxWIn7CgffwdPeN9NIGMYFPuSXPZTovkHqvTAP7w+dODR/iFd5H55OnjOByCFh88284q9PGvX0trT+G1mYjr3zdXySUz4DyqR5ig/nxb/zb3f1vTkwDxajLC/YJa2WVkkPSyPyLyk+9nxMbBCgAAAAAElFTkSuQmCC"/>
     </head>
     <body style="height: 100vh; flex-grow: 1; margin: 0; padding: 0;">
     <script
-    src="https://assets.juno.global.cloud.sap/apps/widget-loader@latest/build/app.js" 
-    data-name="dashboard"
-    data-version="latest"></script>
-    </body>
-    </html>
-
-  exampleapp.html: |
-    <!DOCTYPE html>
-    <html style="margin: 0; padding: 0; display: flex; flex-direction: column;">
-    <head>
-    <title>CCLOUD</title>
-    <link rel="icon" sizes="any" href="https://assets.juno.global.cloud.sap/assets/favicon.ico"/>
-    <link rel="icon" type="image/png" sizes="16x16"href="https://assets.juno.global.cloud.sap/assets/favicon-16x16.png"/>
-    <link rel="icon" type="image/png" sizes="32x32"href="https://assets.juno.global.cloud.sap/assets/favicon-32x32.png"/>
-    </head>
-    <body style="height: 100vh; flex-grow: 1; margin: 0; padding: 0;">
-    <script
-    src="https://assets.juno.global.cloud.sap/apps/widget-loader@latest/build/app.js" 
-    data-name="exampleapp"
-    data-version="latest"></script>
+    src="https://dashboard.eu-de-1.cloud.sap/assets/landing_page_widget.js"></script>
     </body>
     </html>

--- a/ci/helm-charts/hosting/templates/nginx-configmap.yaml
+++ b/ci/helm-charts/hosting/templates/nginx-configmap.yaml
@@ -6,17 +6,9 @@ metadata:
 data:
   nginx.conf: |
     server {
-        listen       80;
-
-        location / {
-            root   /usr/share/nginx/html;
-            index  dashboard.html;
-        }
-    }
-    server {
-      listen 81;
+      listen  80;
       location / {
-        root /usr/share/nginx/html;
-        index exampleapp.html;
+          root   /usr/share/nginx/html;
+          index  dashboard.html;
       }
     }


### PR DESCRIPTION
## Summary

This PR updates the Helm charts to load the dashboard app from Elektra instead of the assets-server. As part of decommissioning the assets-server, the dashboard's source code has been migrated to Elektra.

### Context

- The dashboard needs to be hosted on different DNSs.
- Elektra supports standalone widgets, which allows us to load the dashboard directly from Elektra.

