### PR TITLE
chore(ci): adds a timestamp to src url

### DIFF
--- a/ci/helm-charts/hosting/templates/index-html-configmap.yaml
+++ b/ci/helm-charts/hosting/templates/index-html-configmap.yaml
@@ -13,6 +13,6 @@ data:
     </head>
     <body style="height: 100vh; flex-grow: 1; margin: 0; padding: 0;">
     <script
-    src="https://dashboard.eu-de-1.cloud.sap/assets/landing_page_widget.js"></script>
+    src="https://dashboard.eu-de-1.cloud.sap/assets/landing_page_widget.js?ts={{ now | date "20060102150405" }}"></script>
     </body>
     </html>


### PR DESCRIPTION
This PR adds a timestamp to the url of landing page widget. This allows us to load every time the latest state of the widget.