### PR TITLE
chore(ci): fix tests and cleanup

### DIFF
--- a/ci/pipeline.yaml.erb
+++ b/ci/pipeline.yaml.erb
@@ -10,26 +10,24 @@
   }
   
   ASSETS = {
-    "auth":                 { type: "package", path: "packages/auth", monorepo: false },
-    "assets-overview":      { type: "package", path: "packages/assets-overview", monorepo: false},
-    "user-activity":        { type: "package", path: "packages/user-activity", monorepo: false},
+    #"auth":                 { type: "package", path: "packages/auth", monorepo: false },
+    #"assets-overview":      { type: "package", path: "packages/assets-overview", monorepo: false},
+    #"user-activity":        { type: "package", path: "packages/user-activity", monorepo: false},
     "volta":                { type: "package", path: "packages/volta", monorepo: false},
     "whois":                { type: "package", path: "packages/whois", monorepo: false},
-    "widget-loader":        { type: "package", path: "packages/widget-loader", monorepo: false},
-    "dashboard":            { type: "package", path: "packages/dashboard", monorepo: false},
-    "playground":           { type: "package", path: "packages/playground", monorepo: false},
-    # "policy-engine":        { type: "package", path: "packages/policy-engine"},
+    #"widget-loader":        { type: "package", path: "packages/widget-loader", monorepo: false},
+    #"playground":           { type: "package", path: "packages/playground", monorepo: false},
+    #"policy-engine":        { type: "package", path: "packages/policy-engine"},
   }
 
   CLOUDOPERATOR_ASSETS = {
-    "supernova":           { type: "app", path: "apps/supernova", monorepo: true},
-    "communicator":         { type: "package", path: "packages/communicator", monorepo: true},
-    "messages-provider":    { type: "package", path: "packages/messages-provider", monorepo: true},
-    "ui-components":   { type: "package", path: "packages/ui-components", monorepo: true},    
-    "oauth":                { type: "package", path: "packages/oauth", monorepo: true},
-    "url-state-provider":   { type: "package", path: "packages/url-state-provider", monorepo: true},
-    "url-state-router":     { type: "package", path: "packages/url-state-router", monorepo: true},
-    "utils":                { type: "package", path: "packages/utils", monorepo: true},
+    #"communicator":         { type: "package", path: "packages/communicator", monorepo: true},
+    #"messages-provider":    { type: "package", path: "packages/messages-provider", monorepo: true},
+    #"ui-components":   { type: "package", path: "packages/ui-components", monorepo: true},    
+    #"oauth":                { type: "package", path: "packages/oauth", monorepo: true},
+    #"url-state-provider":   { type: "package", path: "packages/url-state-provider", monorepo: true},
+    #"url-state-router":     { type: "package", path: "packages/url-state-router", monorepo: true},
+    #"utils":                { type: "package", path: "packages/utils", monorepo: true},
   }
 
   HA_REGIONS = ["eu-de-1","eu-de-2","eu-nl-1","ap-ae-1","ap-jp-2","ap-au-1","la-br-1","na-us-1","na-us-2"]

--- a/e2e/cypress/integration/hosting/dashboard.spec.js
+++ b/e2e/cypress/integration/hosting/dashboard.spec.js
@@ -6,11 +6,7 @@ describe("Dashboard", () => {
   it("loads content", () => {
     // content is loaded if children of root element exists.
     // children are built by
-    cy.get('[data-juno-app="dashboard"]')
-      .get('[data-shadow-host="true"]')
-      .shadow()
-      .children()
-      .should("exist")
+    cy.get('[data-shadow-host="true"]').shadow().children().should("exist")
   })
 
   it("contains login button", () => {

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -142,6 +142,6 @@ docker run --rm -it --volume "$E2E_PATH:/e2e" \
   --env CYPRESS_BASE_URL="$HOST" \
   --entrypoint $CY_CMD \
   --network=host \
-  keppel.eu-de-1.cloud.sap/ccloud/cypress-client:latest run "${CY_OPTIONS[@]}" --spec "$SPECS_FOLDER" --browser $CYPRESS_BROWSER
+  keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/cypress/included:12.17.3 run "${CY_OPTIONS[@]}" --spec "$SPECS_FOLDER" --browser $CYPRESS_BROWSER
 # https://github.wdf.sap.corp/cc/secrets/tree/master/ci/cypress-dashboard/Dockerfile
 # https://main.ci.eu-de-2.cloud.sap/teams/services/pipelines/cypress-dashboard/jobs/build-cypress-client-image/


### PR DESCRIPTION
this PR will fix the dashboard hosting tests for the global dashboard and remove all old apps and libs from the CI