### PR TITLE
chore(assets-server): set replicas to 0 for assets-server

### DIFF
--- a/ci/helm-charts/assets_server/templates/deployment.yaml
+++ b/ci/helm-charts/assets_server/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: assets-server
   revisionHistoryLimit: 3
-  replicas: 2
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/ci/helm-charts/assets_server_ha/templates/deployment.yaml
+++ b/ci/helm-charts/assets_server_ha/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: assets-server
   revisionHistoryLimit: 3
-  replicas: 2
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
This PR sets the replica count for the assets-server to 0. This change is necessary to perform a scream test before permanently terminating the service.